### PR TITLE
Refactor datastores in GOB-Core. Adjust import definitions accordingly

### DIFF
--- a/gobconfig/datastore/config.py
+++ b/gobconfig/datastore/config.py
@@ -1,0 +1,85 @@
+import os
+
+from gobconfig.exception import GOBConfigException
+
+TYPE_ORACLE = 'oracle'
+TYPE_POSTGRES = 'postgres'
+TYPE_OBJECTSTORE = 'objectstore'
+
+DATASTORE_CONFIGS = {
+    'Grondslag': {
+        'type': TYPE_ORACLE,
+        'username': os.getenv("DBIMB_DATABASE_USER", "gob"),
+        'password': os.getenv("DBIMB_DATABASE_PASSWORD", "insecure"),
+        'host': os.getenv("DBIMB_DATABASE_HOST", "hostname"),
+        'port': os.getenv("DBIMB_DATABASE_PORT", 1521),
+        'database': os.getenv("DBIMB_DATABASE", "")
+    },
+    'DGDialog': {
+        'type': TYPE_ORACLE,
+        'username': os.getenv("BINBG_DATABASE_USER", "gob"),
+        'password': os.getenv("BINBG_DATABASE_PASSWORD", "insecure"),
+        'host': os.getenv("BINBG_DATABASE_HOST", "hostname"),
+        'port': os.getenv("BINBG_DATABASE_PORT", 1521),
+        'database': os.getenv("BINBG_DATABASE", "")
+    },
+    'DIVA': {
+        'type': TYPE_ORACLE,
+        'username': os.getenv("DBIGM_DATABASE_USER", "gob"),
+        'password': os.getenv("DBIGM_DATABASE_PASSWORD", "insecure"),
+        'host': os.getenv("DBIGM_DATABASE_HOST", "hostname"),
+        'port': os.getenv("DBIGM_DATABASE_PORT", 1521),
+        'database': os.getenv("DBIGM_DATABASE", ""),
+    },
+    'Neuron': {
+        'type': TYPE_ORACLE,
+        'username': os.getenv("BINNRN_DATABASE_USER", "gob"),
+        'password': os.getenv("BINNRN_DATABASE_PASSWORD", "insecure"),
+        'host': os.getenv("BINNRN_DATABASE_HOST", "hostname"),
+        'port': os.getenv("BINNRN_DATABASE_PORT", 1521),
+        'database': os.getenv("BINNRN_DATABASE", ""),
+    },
+    'Decos': {
+        'type': TYPE_ORACLE,
+        'username': os.getenv("DBIDC_DATABASE_USER", "gob"),
+        'password': os.getenv("DBIDC_DATABASE_PASSWORD", "insecure"),
+        'host': os.getenv("DBIDC_DATABASE_HOST", "hostname"),
+        'port': os.getenv("DBIDC_DATABASE_PORT", 1521),
+        'database': os.getenv("DBIDC_DATABASE", ""),
+    },
+    'GOBPrepare': {
+        'type': TYPE_POSTGRES,
+        'username': os.getenv("GOB_PREPARE_DATABASE_USER", "gob"),
+        'password': os.getenv("GOB_PREPARE_DATABASE_PASSWORD", "insecure"),
+        'host': os.getenv("PREPARE_DATABASE_HOST_OVERRIDE", os.getenv("GOB_PREPARE_DATABASE_HOST", "hostname")),
+        'port': os.getenv("PREPARE_DATABASE_PORT_OVERRIDE", os.getenv("GOB_PREPARE_DATABASE_PORT", 5408)),
+        'database': os.getenv("GOB_PREPARE_DATABASE", ""),
+    },
+    'GOBAnalyse': {
+        'type': TYPE_POSTGRES,
+        'username': os.getenv('ANALYSE_DATABASE_USER'),
+        'password': os.getenv('ANALYSE_DATABASE_PASSWORD'),
+        'host': os.getenv('ANALYSE_DATABASE_HOST_OVERRIDE'),
+        'port': os.getenv('ANALYSE_DATABASE_PORT_OVERRIDE'),
+    },
+    'Basisinformatie': {
+        'type': TYPE_OBJECTSTORE,
+        'VERSION': '2.0',
+        'AUTHURL': 'https://identity.stack.cloudvps.com/v2.0',
+        'TENANT_NAME': os.getenv('BASISINFORMATIE_OBJECTSTORE_TENANT_NAME'),
+        'TENANT_ID': os.getenv('BASISINFORMATIE_OBJECTSTORE_TENANT_ID'),
+        'USER': os.getenv('BASISINFORMATIE_OBJECTSTORE_USER'),
+        'PASSWORD': os.getenv('BASISINFORMATIE_OBJECTSTORE_PASSWORD'),
+        'REGION_NAME': 'NL'
+    }
+}
+
+
+def get_datastore_config(name: str) -> dict:
+    try:
+        config = DATASTORE_CONFIGS[name].copy()
+    except KeyError:
+        raise GOBConfigException(f"Datastore config for source {name} not found.")
+
+    config['name'] = name
+    return config

--- a/gobconfig/import_/data/bgt.onderbouw.json
+++ b/gobconfig/import_/data/bgt.onderbouw.json
@@ -6,7 +6,6 @@
     "name": "AMSBI",
     "application": "DGDialog",
     "entity_id": "source_id",
-    "type": "oracle",
     "schema": "dgdialog",
     "query": [
 "    SELECT SUBSTR(t.guid, 2, LENGTH(t.guid) - 2)           AS identificatie",

--- a/gobconfig/import_/data/bgt.overbouw.json
+++ b/gobconfig/import_/data/bgt.overbouw.json
@@ -6,7 +6,6 @@
     "name": "AMSBI",
     "application": "DGDialog",
     "entity_id": "source_id",
-    "type": "oracle",
     "schema": "dgdialog",
     "query": [
 "    SELECT SUBSTR(t.guid, 2, LENGTH(t.guid) - 2)                                    AS identificatie",

--- a/gobconfig/import_/data/bouwblokken.diva.csv.json
+++ b/gobconfig/import_/data/bouwblokken.diva.csv.json
@@ -6,12 +6,13 @@
     "name": "AMSBI",
     "application": "Basisinformatie",
     "entity_id": "identificatie",
-    "type": "objectstore",
-    "file_filter": "gebieden/Bouwblokken/DIVA_gebieden_bouwblokken.csv",
-    "file_type": "CSV",
-    "delimiter": ";",
-    "encoding": "Latin-1",
-    "operators": ["lowercase_keys"]
+    "read_config": {
+      "file_filter": "gebieden/Bouwblokken/DIVA_gebieden_bouwblokken.csv",
+      "file_type": "CSV",
+      "delimiter": ";",
+      "encoding": "Latin-1",
+      "operators": ["lowercase_keys"]
+    }
   },
   "gob_mapping": {
     "identificatie": {

--- a/gobconfig/import_/data/bouwblokken.diva.json
+++ b/gobconfig/import_/data/bouwblokken.diva.json
@@ -6,7 +6,6 @@
     "name": "AMSBI",
     "application": "DIVA",
     "entity_id": "identificatie",
-    "type": "oracle",
     "schema": "diva",
     "query": [
 "    SELECT '0' || d.bbk_id                                                          AS identificatie",

--- a/gobconfig/import_/data/bouwblokken.json
+++ b/gobconfig/import_/data/bouwblokken.json
@@ -6,7 +6,6 @@
     "name": "AMSBI",
     "application": "DGDialog",
     "entity_id": "source_id",
-    "type": "oracle",
     "schema": "dgdialog",
     "merge": {
       "dataset": "bouwblokken.diva.csv.json",

--- a/gobconfig/import_/data/brk.aantekeningenkadastraleobjecten.json
+++ b/gobconfig/import_/data/brk.aantekeningenkadastraleobjecten.json
@@ -6,7 +6,6 @@
     "name": "AMSBI",
     "application": "GOBPrepare",
     "entity_id": "brk_atg_id",
-    "type": "postgres",
     "schema": "GOBPrepare",
     "query": [
       "SELECT * FROM (",

--- a/gobconfig/import_/data/brk.aantekeningenrechten.json
+++ b/gobconfig/import_/data/brk.aantekeningenrechten.json
@@ -6,7 +6,6 @@
     "name": "AMSBI",
     "application": "GOBPrepare",
     "entity_id": "identificatie",
-    "type": "postgres",
     "schema": "GOBPrepare",
     "query": [
       "SELECT * FROM (",

--- a/gobconfig/import_/data/brk.aardzakelijkerechten.json
+++ b/gobconfig/import_/data/brk.aardzakelijkerechten.json
@@ -6,7 +6,6 @@
     "name": "AMSBI",
     "application": "GOBPrepare",
     "entity_id": "code",
-    "type": "postgres",
     "schema": "GOBPrepare",
     "query": [
       "SELECT",

--- a/gobconfig/import_/data/brk.gemeentes.json
+++ b/gobconfig/import_/data/brk.gemeentes.json
@@ -6,8 +6,10 @@
     "name": "Kadaster",
     "application": "PDOK",
     "entity_id": "id",
-    "type": "wfs",
-    "url": "https://geodata.nationaalgeoregister.nl/bestuurlijkegrenzen/wfs?service=WFS&request=getfeature&typename=gemeenten&outputFormat=application/json"
+    "application_config": {
+      "type": "wfs",
+      "url": "https://geodata.nationaalgeoregister.nl/bestuurlijkegrenzen/wfs?service=WFS&request=getfeature&typename=gemeenten&outputFormat=application/json"
+    }
   },
   "gob_mapping": {
     "identificatie": {

--- a/gobconfig/import_/data/brk.kadastralegemeentecodes.json
+++ b/gobconfig/import_/data/brk.kadastralegemeentecodes.json
@@ -6,7 +6,6 @@
     "name": "AMSBI",
     "application": "GOBPrepare",
     "entity_id": "identificatie",
-    "type": "postgres",
     "schema": "GOBPrepare",
     "query": [
       "SELECT",

--- a/gobconfig/import_/data/brk.kadastralegemeentes.json
+++ b/gobconfig/import_/data/brk.kadastralegemeentes.json
@@ -6,7 +6,6 @@
     "name": "AMSBI",
     "application": "GOBPrepare",
     "entity_id": "identificatie",
-    "type": "postgres",
     "schema": "GOBPrepare",
     "query": [
       "SELECT",

--- a/gobconfig/import_/data/brk.kadastraleobjecten.json
+++ b/gobconfig/import_/data/brk.kadastraleobjecten.json
@@ -6,7 +6,6 @@
     "name": "AMSBI",
     "application": "GOBPrepare",
     "entity_id": "nrn_kot_id",
-    "type": "postgres",
     "schema": "GOBPrepare",
     "query": [
       "SELECT",

--- a/gobconfig/import_/data/brk.kadastralesecties.json
+++ b/gobconfig/import_/data/brk.kadastralesecties.json
@@ -6,7 +6,6 @@
     "name": "AMSBI",
     "application": "GOBPrepare",
     "entity_id": "identificatie",
-    "type": "postgres",
     "schema": "GOBPrepare",
     "query": [
       "SELECT",

--- a/gobconfig/import_/data/brk.kadastralesubjecten.json
+++ b/gobconfig/import_/data/brk.kadastralesubjecten.json
@@ -6,7 +6,6 @@
     "name": "AMSBI",
     "application": "GOBPrepare",
     "entity_id": "nrn_sjt_id",
-    "type": "postgres",
     "schema": "GOBPrepare",
     "query": [
       "SELECT * FROM (",

--- a/gobconfig/import_/data/brk.meta.json
+++ b/gobconfig/import_/data/brk.meta.json
@@ -6,7 +6,6 @@
     "name": "AMSBI",
     "application": "GOBPrepare",
     "entity_id": "id",
-    "type": "postgres",
     "schema": "GOBPrepare",
     "query": [
       "SELECT id, toestandsdatum FROM brk_prepared.meta"

--- a/gobconfig/import_/data/brk.stukdelen.json
+++ b/gobconfig/import_/data/brk.stukdelen.json
@@ -6,7 +6,6 @@
     "name": "AMSBI",
     "application": "GOBPrepare",
     "entity_id": "nrn_sdl_id",
-    "type": "postgres",
     "schema": "GOBPrepare",
     "query": [
       "SELECT * FROM (",

--- a/gobconfig/import_/data/brk.tenaamstellingen.json
+++ b/gobconfig/import_/data/brk.tenaamstellingen.json
@@ -6,7 +6,6 @@
     "name": "AMSBI",
     "application": "GOBPrepare",
     "entity_id": "nrn_tng_id",
-    "type": "postgres",
     "schema": "GOBPrepare",
     "query": [
       "SELECT",

--- a/gobconfig/import_/data/brk.zakelijkerechten.json
+++ b/gobconfig/import_/data/brk.zakelijkerechten.json
@@ -6,7 +6,6 @@
     "name": "AMSBI",
     "application": "GOBPrepare",
     "entity_id": "id",
-    "type": "postgres",
     "schema": "GOBPrepare",
     "query": [
       "SELECT",

--- a/gobconfig/import_/data/brondocumenten.json
+++ b/gobconfig/import_/data/brondocumenten.json
@@ -6,7 +6,6 @@
     "name": "AMSBI",
     "application": "Decos",
     "entity_id": "documentnummer",
-    "type": "oracle",
     "schema": "Decos",
     "query": [
 "    SELECT b.subject2                                          AS documentnummer",

--- a/gobconfig/import_/data/buurten.diva.csv.json
+++ b/gobconfig/import_/data/buurten.diva.csv.json
@@ -6,12 +6,13 @@
     "name": "AMSBI",
     "application": "Basisinformatie",
     "entity_id": "identificatie",
-    "type": "objectstore",
-    "file_filter": "gebieden/Buurten/DIVA_gebieden_buurten.csv",
-    "file_type": "CSV",
-    "delimiter": ";",
-    "encoding": "UTF-8",
-    "operators": ["lowercase_keys"]
+    "read_config": {
+      "file_filter": "gebieden/Buurten/DIVA_gebieden_buurten.csv",
+      "file_type": "CSV",
+      "delimiter": ";",
+      "encoding": "UTF-8",
+      "operators": ["lowercase_keys"]
+    }
   },
   "gob_mapping": {
     "identificatie": {

--- a/gobconfig/import_/data/buurten.diva.json
+++ b/gobconfig/import_/data/buurten.diva.json
@@ -6,7 +6,6 @@
     "name": "AMSBI",
     "application": "DIVA",
     "entity_id": "identificatie",
-    "type": "oracle",
     "schema": "diva",
     "query": [
       "    SELECT '0' || d.brt_id                                                          AS identificatie",

--- a/gobconfig/import_/data/buurten.json
+++ b/gobconfig/import_/data/buurten.json
@@ -6,7 +6,6 @@
     "name": "AMSBI",
     "application": "DGDialog",
     "entity_id": "source_id",
-    "type": "oracle",
     "schema": "dgdialog",
     "merge": {
       "dataset": "buurten.diva.csv.json",

--- a/gobconfig/import_/data/dossiers.json
+++ b/gobconfig/import_/data/dossiers.json
@@ -6,7 +6,6 @@
     "name": "AMSBI",
     "application": "Decos",
     "entity_id": "dossier",
-    "type": "oracle",
     "schema": "Decos",
     "query": [
 "    SELECT * FROM (",

--- a/gobconfig/import_/data/ggpgebieden.json
+++ b/gobconfig/import_/data/ggpgebieden.json
@@ -6,9 +6,10 @@
     "name": "AMSBI",
     "application": "Basisinformatie",
     "entity_id": "GGP_CODE",
-    "type": "objectstore",
-    "file_filter": "gebieden/GGW_praktijkgebieden/GGP\\.xlsx$",
-    "file_type": "XLS",
+    "read_config": {
+      "file_filter": "gebieden/GGW_praktijkgebieden/GGP\\.xlsx$",
+      "file_type": "XLS"
+    },
     "depends_on": {
       "catalogue": "gebieden",
       "entity": "buurten"

--- a/gobconfig/import_/data/ggwgebieden.json
+++ b/gobconfig/import_/data/ggwgebieden.json
@@ -6,9 +6,10 @@
     "name": "AMSBI",
     "application": "Basisinformatie",
     "entity_id": "GGW_CODE",
-    "type": "objectstore",
-    "file_filter": "gebieden/GGW_gebieden/GGW\\.xlsx$",
-    "file_type": "XLS",
+    "read_config": {
+      "file_filter": "gebieden/GGW_gebieden/GGW\\.xlsx$",
+      "file_type": "XLS"
+    },
     "depends_on": {
       "catalogue": "gebieden",
       "entity": "buurten"

--- a/gobconfig/import_/data/ligplaatsen.json
+++ b/gobconfig/import_/data/ligplaatsen.json
@@ -6,7 +6,6 @@
     "name": "AMSBI",
     "application": "Neuron",
     "entity_id": "identificatie",
-    "type": "oracle",
     "schema": "Neuron",
     "enrich": {
       "amsterdamse_sleutel": {

--- a/gobconfig/import_/data/meetbouten.json
+++ b/gobconfig/import_/data/meetbouten.json
@@ -6,7 +6,6 @@
     "name": "AMSBI",
     "application": "Grondslag",
     "entity_id": "identificatie",
-    "type": "oracle",
     "schema": "grondslag",
     "query": [
 "      SELECT h.nummer AS identificatie",

--- a/gobconfig/import_/data/metingen.json
+++ b/gobconfig/import_/data/metingen.json
@@ -6,7 +6,6 @@
     "name": "AMSBI",
     "application": "Grondslag",
     "entity_id": "identificatie",
-    "type": "oracle",
     "schema": "grondslag",
     "query": [
 "    SELECT * FROM (",

--- a/gobconfig/import_/data/nummeraanduidingen.json
+++ b/gobconfig/import_/data/nummeraanduidingen.json
@@ -6,7 +6,6 @@
     "name": "AMSBI",
     "application": "Neuron",
     "entity_id": "identificatie",
-    "type": "oracle",
     "schema": "Neuron",
     "enrich": {
       "amsterdamse_sleutel": {

--- a/gobconfig/import_/data/openbareruimtes.json
+++ b/gobconfig/import_/data/openbareruimtes.json
@@ -6,7 +6,6 @@
     "name": "AMSBI",
     "application": "Neuron",
     "entity_id": "identificatie",
-    "type": "oracle",
     "schema": "Neuron",
     "enrich": {
       "amsterdamse_sleutel": {

--- a/gobconfig/import_/data/panden.json
+++ b/gobconfig/import_/data/panden.json
@@ -6,7 +6,6 @@
     "name": "AMSBI",
     "application": "Neuron",
     "entity_id": "identificatie",
-    "type": "oracle",
     "schema": "Neuron",
     "enrich": {
       "amsterdamse_sleutel": {

--- a/gobconfig/import_/data/peilmerken.json
+++ b/gobconfig/import_/data/peilmerken.json
@@ -6,7 +6,6 @@
     "name": "AMSBI",
     "application": "Grondslag",
     "entity_id": "identificatie",
-    "type": "oracle",
     "schema": "grondslag",
     "query": [
 "    SELECT h.nummer                                 AS identificatie",

--- a/gobconfig/import_/data/referentiepunten.json
+++ b/gobconfig/import_/data/referentiepunten.json
@@ -6,7 +6,6 @@
     "name": "AMSBI",
     "application": "Grondslag",
     "entity_id": "identificatie",
-    "type": "oracle",
     "schema": "grondslag",
     "query": [
 "      SELECT h.nummer                                                       AS identificatie",

--- a/gobconfig/import_/data/rel.wkpb_bpg_brk_kot_belast_kadastrale_objecten.json
+++ b/gobconfig/import_/data/rel.wkpb_bpg_brk_kot_belast_kadastrale_objecten.json
@@ -6,7 +6,6 @@
     "name": "AMSBI",
     "application": "GOBPrepare",
     "entity_id": "id",
-    "type": "postgres",
     "schema": "GOBPrepare",
     "query": [
       "SELECT",

--- a/gobconfig/import_/data/rollagen.json
+++ b/gobconfig/import_/data/rollagen.json
@@ -6,8 +6,9 @@
     "name": "AMSBI",
     "application": "Basisinformatie",
     "entity_id": "name",
-    "type": "objectstore",
-    "file_filter": "meetbouten/rollagen/.+\\.jpg$"
+    "read_config": {
+      "file_filter": "meetbouten/rollagen/.+\\.jpg$"
+    }
   },
   "gob_mapping": {
     "identificatie": {

--- a/gobconfig/import_/data/secure.csv.json
+++ b/gobconfig/import_/data/secure.csv.json
@@ -6,12 +6,13 @@
     "name": "AMSBI",
     "application": "Basisinformatie",
     "entity_id": "id",
-    "type": "objectstore",
-    "file_filter": "secure/secure.csv",
-    "file_type": "CSV",
-    "delimiter": ",",
-    "encoding": "Latin-1",
-    "operators": ["lowercase_keys"]
+    "read_config": {
+      "file_filter": "secure/secure.csv",
+      "file_type": "CSV",
+      "delimiter": ",",
+      "encoding": "Latin-1",
+      "operators": ["lowercase_keys"]
+    }
   },
   "gob_mapping": {
     "id": {

--- a/gobconfig/import_/data/stadsdelen.diva.csv.json
+++ b/gobconfig/import_/data/stadsdelen.diva.csv.json
@@ -6,12 +6,13 @@
     "name": "AMSBI",
     "application": "Basisinformatie",
     "entity_id": "identificatie",
-    "type": "objectstore",
-    "file_filter": "gebieden/Stadsdelen/DIVA_gebieden_stadsdelen.csv",
-    "file_type": "CSV",
-    "delimiter": ";",
-    "encoding": "Latin-1",
-    "operators": ["lowercase_keys"]
+    "read_config": {
+      "file_filter": "gebieden/Stadsdelen/DIVA_gebieden_stadsdelen.csv",
+      "file_type": "CSV",
+      "delimiter": ";",
+      "encoding": "Latin-1",
+      "operators": ["lowercase_keys"]
+    }
   },
   "gob_mapping": {
     "identificatie": {

--- a/gobconfig/import_/data/stadsdelen.diva.json
+++ b/gobconfig/import_/data/stadsdelen.diva.json
@@ -6,7 +6,6 @@
     "name": "AMSBI",
     "application": "DIVA",
     "entity_id": "identificatie",
-    "type": "oracle",
     "schema": "diva",
     "query": [
 "    SELECT '0' || d.sdl_id                                                          AS identificatie",

--- a/gobconfig/import_/data/stadsdelen.json
+++ b/gobconfig/import_/data/stadsdelen.json
@@ -6,7 +6,6 @@
     "name": "AMSBI",
     "application": "DGDialog",
     "entity_id": "source_id",
-    "type": "oracle",
     "schema": "dgdialog",
     "merge": {
       "dataset": "stadsdelen.diva.csv.json",

--- a/gobconfig/import_/data/standplaatsen.json
+++ b/gobconfig/import_/data/standplaatsen.json
@@ -6,7 +6,6 @@
     "name": "AMSBI",
     "application": "Neuron",
     "entity_id": "identificatie",
-    "type": "oracle",
     "schema": "Neuron",
     "enrich": {
       "amsterdamse_sleutel": {

--- a/gobconfig/import_/data/test/test.json
+++ b/gobconfig/import_/data/test/test.json
@@ -8,7 +8,7 @@
     "application": "TEST",
     "entity_id": "string",
     "type": "file",
-    "config": {
+    "application_config": {
       "filename": "test/test.csv",
       "filetype": "CSV",
       "separator": ",",

--- a/gobconfig/import_/data/test_ADD.json
+++ b/gobconfig/import_/data/test_ADD.json
@@ -7,9 +7,11 @@
     "name": "test",
     "application": "ADD",
     "entity_id": "string",
-    "type": "file",
-    "config": {
-      "filename": "test/test_ADD.csv",
+    "application_config": {
+      "type": "file",
+      "filename": "test/test_ADD.csv"
+    },
+    "read_config": {
       "filetype": "CSV",
       "separator": ",",
       "encoding": "UTF-8"

--- a/gobconfig/import_/data/test_AUTOID.json
+++ b/gobconfig/import_/data/test_AUTOID.json
@@ -6,9 +6,11 @@
     "name": "test",
     "application": "AUTOID",
     "entity_id": "identificatie",
-    "type": "file",
-    "config": {
-      "filename": "test/test_AUTOID.csv",
+    "application_config": {
+      "type": "file",
+      "filename": "test/test_AUTOID.csv"
+    },
+    "read_config": {
       "filetype": "CSV",
       "separator": ",",
       "encoding": "UTF-8"

--- a/gobconfig/import_/data/test_AUTOID_ADD.json
+++ b/gobconfig/import_/data/test_AUTOID_ADD.json
@@ -7,9 +7,11 @@
     "name": "test",
     "application": "AUTOID_ADD",
     "entity_id": "identificatie",
-    "type": "file",
-    "config": {
-      "filename": "test/test_AUTOID_ADD.csv",
+    "application_config": {
+      "type": "file",
+      "filename": "test/test_AUTOID_ADD.csv"
+    },
+    "read_config": {
       "filetype": "CSV",
       "separator": ",",
       "encoding": "UTF-8"

--- a/gobconfig/import_/data/test_AUTOID_DELETE.json
+++ b/gobconfig/import_/data/test_AUTOID_DELETE.json
@@ -7,9 +7,11 @@
     "name": "test",
     "application": "AUTOID_DELETE",
     "entity_id": "identificatie",
-    "type": "file",
-    "config": {
-      "filename": "test/test_AUTOID_DELETE.csv",
+    "application_config": {
+      "type": "file",
+      "filename": "test/test_AUTOID_DELETE.csv"
+    },
+    "read_config": {
       "filetype": "CSV",
       "separator": ",",
       "encoding": "UTF-8"

--- a/gobconfig/import_/data/test_AUTOID_MODIFY.json
+++ b/gobconfig/import_/data/test_AUTOID_MODIFY.json
@@ -7,9 +7,11 @@
     "name": "test",
     "application": "AUTOID_MODIFY",
     "entity_id": "identificatie",
-    "type": "file",
-    "config": {
-      "filename": "test/test_AUTOID_MODIFY.csv",
+    "application_config": {
+      "type": "file",
+      "filename": "test/test_AUTOID_MODIFY.csv"
+    },
+    "read_config": {
       "filetype": "CSV",
       "separator": ",",
       "encoding": "UTF-8"

--- a/gobconfig/import_/data/test_DELETE_ALL.json
+++ b/gobconfig/import_/data/test_DELETE_ALL.json
@@ -7,9 +7,11 @@
     "name": "test",
     "application": "DELETE_ALL",
     "entity_id": "string",
-    "type": "file",
-    "config": {
-      "filename": "test/test_DELETE_ALL.csv",
+    "application_config": {
+      "type": "file",
+      "filename": "test/test_DELETE_ALL.csv"
+    },
+    "read_config": {
       "filetype": "CSV",
       "separator": ",",
       "encoding": "UTF-8"

--- a/gobconfig/import_/data/test_MODIFY1.json
+++ b/gobconfig/import_/data/test_MODIFY1.json
@@ -7,9 +7,11 @@
     "name": "test",
     "application": "MODIFY1",
     "entity_id": "string",
-    "type": "file",
-    "config": {
-      "filename": "test/test_MODIFY1.csv",
+    "application_config": {
+      "type": "file",
+      "filename": "test/test_MODIFY1.csv"
+    },
+    "read_config": {
       "filetype": "CSV",
       "separator": ",",
       "encoding": "UTF-8"

--- a/gobconfig/import_/data/test_REFS.json
+++ b/gobconfig/import_/data/test_REFS.json
@@ -7,9 +7,11 @@
     "name": "test",
     "application": "ADD",
     "entity_id": "string",
-    "type": "file",
-    "config": {
-      "filename": "test/test_REFS.csv",
+    "application_config": {
+      "type": "file",
+      "filename": "test/test_REFS.csv"
+    },
+    "read_config": {
       "filetype": "CSV",
       "separator": ",",
       "encoding": "UTF-8"

--- a/gobconfig/import_/data/test_REFS_MODIFY1.json
+++ b/gobconfig/import_/data/test_REFS_MODIFY1.json
@@ -7,9 +7,11 @@
     "name": "test",
     "application": "MODIFY1",
     "entity_id": "string",
-    "type": "file",
-    "config": {
-      "filename": "test/test_REFS.csv",
+    "application_config": {
+      "type": "file",
+      "filename": "test/test_REFS.csv"
+    },
+    "read_config": {
       "filetype": "CSV",
       "separator": ",",
       "encoding": "UTF-8"

--- a/gobconfig/import_/data/test_rel_entity_a.json
+++ b/gobconfig/import_/data/test_rel_entity_a.json
@@ -6,9 +6,11 @@
     "name": "test",
     "application": "REL",
     "entity_id": "id",
-    "type": "file",
-    "config": {
-      "filename": "test/test_catalogue_rel_test_entity_a.csv",
+    "application_config": {
+      "type": "file",
+      "filename": "test/test_catalogue_rel_test_entity_a.csv"
+    },
+    "read_config": {
       "filetype": "CSV",
       "separator": ",",
       "encoding": "UTF-8"

--- a/gobconfig/import_/data/test_rel_entity_b.json
+++ b/gobconfig/import_/data/test_rel_entity_b.json
@@ -6,9 +6,11 @@
     "name": "test",
     "application": "REL",
     "entity_id": "id",
-    "type": "file",
-    "config": {
-      "filename": "test/test_catalogue_rel_test_entity_b.csv",
+    "application_config": {
+      "type": "file",
+      "filename": "test/test_catalogue_rel_test_entity_b.csv"
+    },
+    "read_config": {
       "filetype": "CSV",
       "separator": ",",
       "encoding": "UTF-8"

--- a/gobconfig/import_/data/test_rel_entity_c.json
+++ b/gobconfig/import_/data/test_rel_entity_c.json
@@ -6,9 +6,11 @@
     "name": "test",
     "application": "REL",
     "entity_id": "id",
-    "type": "file",
-    "config": {
-      "filename": "test/test_catalogue_rel_test_entity_c.csv",
+    "application_config": {
+      "type": "file",
+      "filename": "test/test_catalogue_rel_test_entity_c.csv"
+    },
+    "read_config": {
       "filetype": "CSV",
       "separator": ",",
       "encoding": "UTF-8"

--- a/gobconfig/import_/data/test_rel_entity_d.json
+++ b/gobconfig/import_/data/test_rel_entity_d.json
@@ -6,9 +6,11 @@
     "name": "test",
     "application": "REL",
     "entity_id": "id",
-    "type": "file",
-    "config": {
-      "filename": "test/test_catalogue_rel_test_entity_d.csv",
+    "application_config": {
+      "type": "file",
+      "filename": "test/test_catalogue_rel_test_entity_d.csv"
+    },
+    "read_config": {
       "filetype": "CSV",
       "separator": ",",
       "encoding": "UTF-8"

--- a/gobconfig/import_/data/verblijfsobjecten.json
+++ b/gobconfig/import_/data/verblijfsobjecten.json
@@ -6,7 +6,6 @@
     "name": "AMSBI",
     "application": "Neuron",
     "entity_id": "identificatie",
-    "type": "oracle",
     "schema": "Neuron",
     "enrich": {
       "amsterdamse_sleutel": {

--- a/gobconfig/import_/data/wijken.diva.csv.json
+++ b/gobconfig/import_/data/wijken.diva.csv.json
@@ -6,12 +6,13 @@
     "name": "AMSBI",
     "application": "Basisinformatie",
     "entity_id": "identificatie",
-    "type": "objectstore",
-    "file_filter": "gebieden/Wijken/DIVA_gebieden_wijken.csv",
-    "file_type": "CSV",
-    "delimiter": ";",
-    "encoding": "UTF-8",
-    "operators": ["lowercase_keys"]
+    "read_config": {
+      "file_filter": "gebieden/Wijken/DIVA_gebieden_wijken.csv",
+      "file_type": "CSV",
+      "delimiter": ";",
+      "encoding": "UTF-8",
+      "operators": ["lowercase_keys"]
+    }
   },
   "gob_mapping": {
     "identificatie": {

--- a/gobconfig/import_/data/wijken.diva.json
+++ b/gobconfig/import_/data/wijken.diva.json
@@ -6,7 +6,6 @@
     "name": "AMSBI",
     "application": "DIVA",
     "entity_id": "identificatie",
-    "type": "oracle",
     "schema": "diva",
     "query": [
 "    SELECT '0' || d.bce_id                                                          AS identificatie",

--- a/gobconfig/import_/data/wijken.json
+++ b/gobconfig/import_/data/wijken.json
@@ -6,7 +6,6 @@
     "name": "AMSBI",
     "application": "DGDialog",
     "entity_id": "source_id",
-    "type": "oracle",
     "schema": "dgdialog",
     "merge": {
       "dataset": "wijken.diva.csv.json",

--- a/gobconfig/import_/data/wkpb.beperkingen.json
+++ b/gobconfig/import_/data/wkpb.beperkingen.json
@@ -6,7 +6,6 @@
     "name": "AMSBI",
     "application": "Neuron",
     "entity_id": "identificatie",
-    "type": "oracle",
     "schema": "Neuron",
     "query": [
       "SELECT b.registernummer                                       AS identificatie --inschrijfnummer",

--- a/gobconfig/import_/data/wkpb.brondocumenten.json
+++ b/gobconfig/import_/data/wkpb.brondocumenten.json
@@ -6,7 +6,6 @@
     "name": "AMSBI",
     "application": "Decos",
     "entity_id": "documentnummer",
-    "type": "oracle",
     "schema": "Decos",
     "query": [
       "SELECT b.subject2                                       AS documentnummer",

--- a/gobconfig/import_/data/wkpb.dossiers.json
+++ b/gobconfig/import_/data/wkpb.dossiers.json
@@ -6,7 +6,6 @@
     "name": "AMSBI",
     "application": "Decos",
     "entity_id": "dossier",
-    "type": "oracle",
     "schema": "Decos",
     "query": [
       "SELECT TRIM(NVL(regexp_substr(substr(b.subject2, 1, 21), '^(.*?)_', 1, 1, NULL, 1), substr(b.subject2, 1, 21))) AS dossier",

--- a/gobconfig/import_/data/woonplaatsen.json
+++ b/gobconfig/import_/data/woonplaatsen.json
@@ -6,7 +6,6 @@
     "name": "AMSBI",
     "application": "Neuron",
     "entity_id": "identificatie",
-    "type": "oracle",
     "schema": "Neuron",
     "enrich": {
       "amsterdamse_sleutel": {

--- a/gobconfig/import_/import_config.py
+++ b/gobconfig/import_/import_config.py
@@ -60,19 +60,27 @@ def get_dataset_file_location(catalogue: str, collection: str, application: str 
                                  f"{catalogue}, {collection}, {application}")
 
 
-def get_mapping(input_name):
+def get_mapping(filename):
     """
     Read a mapping from a file
 
-    :param input_name: name of the file that contains the mapping
+    :param filename: name of the file that contains the mapping
     :return: an object that contains the mapping
     """
-    with open(input_name) as file:
-        return json.load(file)
+    with open(filename) as file:
+        mapping = json.load(file)
+
+        source_filename = mapping.get('source', {}).get('application_config', {}).get('filename')
+
+        # Set source path to absolute filepath if filename exists in source config
+        if source_filename:
+            mapping['source']['application_config']['filepath'] = get_absolute_filepath(source_filename)
+
+        return mapping
 
 
 def get_absolute_filepath(filename: str):
-    """Returns absolute filepath for filename. filename should be relatei to the data directory.
+    """Returns absolute filepath for filename. filename should be relative to the data directory.
 
     :param filename:
     :return:

--- a/tests/datastore/test_config.py
+++ b/tests/datastore/test_config.py
@@ -1,0 +1,45 @@
+from unittest import TestCase
+from unittest.mock import patch
+
+from gobconfig.datastore.config import (
+    GOBConfigException,
+    get_datastore_config,
+    TYPE_POSTGRES,
+    TYPE_OBJECTSTORE,
+    TYPE_ORACLE,
+    DATASTORE_CONFIGS
+)
+
+
+class TestConfig(TestCase):
+
+    mock_config = {
+        'DatastoreA': {
+            'some': 'config',
+        }
+    }
+
+    @patch("gobconfig.datastore.config.DATASTORE_CONFIGS", mock_config)
+    def test_datastore_config(self):
+
+        self.assertEqual({
+            'some': 'config',
+            'name': 'DatastoreA',
+        }, get_datastore_config('DatastoreA'))
+
+        with self.assertRaises(GOBConfigException):
+            get_datastore_config('NonExistent')
+
+    def test_valid_types(self):
+        """Tests that all configs have a valid type set
+
+        :return:
+        """
+        valid_types = [
+            TYPE_ORACLE,
+            TYPE_OBJECTSTORE,
+            TYPE_POSTGRES,
+        ]
+
+        for name, config in DATASTORE_CONFIGS.items():
+            self.assertTrue(config.get('type') in valid_types)

--- a/tests/gobconfig/import_/test_import_config.py
+++ b/tests/gobconfig/import_/test_import_config.py
@@ -9,7 +9,8 @@ from gobconfig.import_.import_config import (
     _build_dataset_locations_mapping,
     get_import_definition,
     get_import_definition_by_filename,
-    get_absolute_filepath
+    get_absolute_filepath,
+    get_mapping
 )
 
 from collections import defaultdict
@@ -112,6 +113,24 @@ class TestImportConfig(TestCase):
 
         with self.assertRaisesRegexp(GOBConfigException, "Dataset file mocked/data/dir/file.json invalid"):
             _build_dataset_locations_mapping()
+
+    @patch("builtins.open")
+    @patch("gobconfig.import_.import_config.json.load")
+    @patch("gobconfig.import_.import_config.get_absolute_filepath", lambda x: '/path/to/' + x)
+    def test_get_mapping(self, mock_load, mock_open):
+        mock_load.return_value = {
+            'source': {
+                'application_config': {
+                    'filename': 'the_filename',
+                }
+            }
+        }
+        mock_file = mock_open.return_value.__enter__.return_value
+
+        result = get_mapping('filename')
+
+        self.assertEqual('/path/to/the_filename', result['source']['application_config']['filepath'])
+        mock_load.assert_called_with(mock_file)
 
     @patch("gobconfig.import_.import_config.DATASET_DIR", "mocked/data/dir/")
     def test_get_absolute_filepath(self):


### PR DESCRIPTION
- Removed the "type" key from all import definitions, as type should be opaque to import.

Changed the import definition layout a bit:
- application_config overrides the application, so that not all applications need to be explicitly defined.
- read_config contains the configuration that is not important for connecting, but is for reading (such as the file filter in objectstore connections).
