### PR TITLE
Remove dry_run for Amsterdamse Sleutel

### DIFF
--- a/gobconfig/import_/data/ligplaatsen.json
+++ b/gobconfig/import_/data/ligplaatsen.json
@@ -11,8 +11,7 @@
       "amsterdamse_sleutel": {
         "type": "autoid",
         "on": "identificatie",
-        "template": "0363085XXXXXXX",
-        "dry_run": true
+        "template": "0363085XXXXXXX"
       }
     },
     "query": [

--- a/gobconfig/import_/data/nummeraanduidingen.json
+++ b/gobconfig/import_/data/nummeraanduidingen.json
@@ -11,8 +11,7 @@
       "amsterdamse_sleutel": {
         "type": "autoid",
         "on": "identificatie",
-        "template": "0363087XXXXXXX",
-        "dry_run": true
+        "template": "0363087XXXXXXX"
       }
     },
     "query": [

--- a/gobconfig/import_/data/openbareruimtes.json
+++ b/gobconfig/import_/data/openbareruimtes.json
@@ -11,8 +11,7 @@
       "amsterdamse_sleutel": {
         "type": "autoid",
         "on": "identificatie",
-        "template": "0363088XXXXXXX",
-        "dry_run": true
+        "template": "0363088XXXXXXX"
       }
     },
     "query": [

--- a/gobconfig/import_/data/panden.json
+++ b/gobconfig/import_/data/panden.json
@@ -11,8 +11,7 @@
       "amsterdamse_sleutel": {
         "type": "autoid",
         "on": "identificatie",
-        "template": "0363083XXXXXXX",
-        "dry_run": true
+        "template": "0363083XXXXXXX"
       }
     },
     "query": [

--- a/gobconfig/import_/data/standplaatsen.json
+++ b/gobconfig/import_/data/standplaatsen.json
@@ -11,8 +11,7 @@
       "amsterdamse_sleutel": {
         "type": "autoid",
         "on": "identificatie",
-        "template": "0363084XXXXXXX",
-        "dry_run": true
+        "template": "0363084XXXXXXX"
       }
     },
     "query": [

--- a/gobconfig/import_/data/verblijfsobjecten.json
+++ b/gobconfig/import_/data/verblijfsobjecten.json
@@ -11,8 +11,7 @@
       "amsterdamse_sleutel": {
         "type": "autoid",
         "on": "identificatie",
-        "template": "0363086XXXXXXX",
-        "dry_run": true
+        "template": "0363086XXXXXXX"
       }
     },
     "query": [

--- a/gobconfig/import_/data/woonplaatsen.json
+++ b/gobconfig/import_/data/woonplaatsen.json
@@ -11,8 +11,7 @@
       "amsterdamse_sleutel": {
         "type": "autoid",
         "on": "identificatie",
-        "template": "0363089XXXXXXX",
-        "dry_run": true
+        "template": "0363089XXXXXXX"
       }
     },
     "query": [


### PR DESCRIPTION
Without the dry_run parameter GOB will generate the Amsterdamse Sleutel
Before, this was done by DIVA