### PR TITLE
Fix bug in max_date function and BAG queries

### DIFF
--- a/gobconfig/import_/data/sql/bag/nummeraanduidingen.sql
+++ b/gobconfig/import_/data/sql/bag/nummeraanduidingen.sql
@@ -1,9 +1,9 @@
 WITH
     -- Utility functions
     -- Use max_date if eindgeldigheid is NULL
-    FUNCTION max_date RETURN char AS
+    FUNCTION max_date RETURN DATE AS
     BEGIN
-        RETURN to_date(9999, 'yyyy');
+        RETURN to_date('9999', 'yyyy');
     END;
     -- Determine if a cycle of an objectklasse is in onderzoek
     FUNCTION cyclus_in_onderzoek(
@@ -33,29 +33,6 @@ WITH
         ELSE RETURN 0;
         END IF;
 	END;
-    -- SubQuery Factoring for onderzoeken
-    -- Alle onderzoeken voor deze objectklasse
-    in_onderzoeken AS (SELECT /*+ MATERIALIZE */
-                              identificatie
-                            , versie_identificatie
-                            , object_identificatie
-                            , inonderzoek
-                            , to_date(begin_geldigheid, 'yyyy-mm-dd')                 AS begin_onderzoek
-                            , nvl(to_date(eind_geldigheid, 'yyyy-mm-dd'), max_date()) AS eind_onderzoek
-                       FROM   lvbag.inonderzoek
-                       WHERE  objecttype = 21 ORDER BY object_identificatie),
-    -- All onderzoeken gegroepeerd per dag op maximum versie
-    -- Onderzoeken die meerdere statussen hebben per dag worden beoordeeld op de status aan het einde van de dag
-    in_onderzoeken_eod AS (SELECT /*+ MATERIALIZE */ io.*
-            	 	       FROM in_onderzoeken io
-                           INNER JOIN (SELECT   identificatie
-                                              , begin_onderzoek
-                                              , max(versie_identificatie) AS maxversie
-                                       FROM     in_onderzoeken
-                                       GROUP BY identificatie, begin_onderzoek) io_eod
-                           ON io.identificatie = io_eod.identificatie AND
-                              io.versie_identificatie = io_eod.maxversie
-                           WHERE io.inonderzoek = 'J'),
     -- SubQuery factoring for objectklasse dataset
     authentieke_objecten AS (SELECT *
                              FROM   basis.adres
@@ -64,21 +41,56 @@ WITH
     -- begindatum gebruiken als einddatum volgende cyclus
     begin_cyclus AS (SELECT adresnummer
 	                      , adresvolgnummer
+                          , datumopvoer
 	                      , 1 + dense_rank() OVER (partition BY adresnummer ORDER BY adresvolgnummer) AS rang
 	                 FROM   authentieke_objecten),
     eind_cyclus AS (SELECT adresnummer
 	                     , adresvolgnummer
 	                     , datumopvoer
-                         , nvl(trunc(datumopvoer), max_date()) as eind_cyclus
 	                     , dense_rank() OVER (partition BY adresnummer ORDER BY adresvolgnummer) AS rang
 	                FROM   authentieke_objecten),
-    -- SubQuery factoring for shared datasets
-    adressen AS (SELECT   adres_id
-                        , adresnummer
-                 FROM     basis.adres
-                 WHERE    indauthentiek = 'J'
-                 GROUP BY adres_id, adresnummer)
-SELECT a.adresnummer                                                                          AS identificatie
+ 	cyclus AS (SELECT bc.adresnummer                         AS object_nummer
+	                , bc.adresvolgnummer                     AS object_volgnummer
+	                , trunc(bc.datumopvoer)                  AS begin_cyclus
+	                , nvl(trunc(ec.datumopvoer), max_date()) AS eind_cyclus
+	           FROM begin_cyclus bc
+	           LEFT OUTER JOIN eind_cyclus ec ON  bc.adresnummer = ec.adresnummer AND
+							                      bc.rang = ec.rang),
+    -- SubQuery Factoring for onderzoeken
+    -- All onderzoeken gegroepeerd per onderzoek per object per dag op de toestand aan het einde van de dag
+    inonderzoeken_per_dag AS (SELECT identificatie
+                                   , object_identificatie
+                                   , begin_geldigheid
+                                   , max(versie_identificatie) AS eodversie
+                              FROM   lvbag.inonderzoek
+                              WHERE  objecttype = 21
+                              GROUP BY identificatie, object_identificatie, begin_geldigheid),
+    in_onderzoeken AS (SELECT io.identificatie
+                            , io.versie_identificatie
+                            , io.object_identificatie
+                            , io.inonderzoek
+                            , to_date(io.begin_geldigheid, 'yyyy-mm-dd')                 AS begin_onderzoek
+                            , nvl(to_date(io.eind_geldigheid, 'yyyy-mm-dd'), max_date()) AS eind_onderzoek
+                       FROM   lvbag.inonderzoek io
+                       INNER JOIN inonderzoeken_per_dag io_pd
+                               ON io.identificatie = io_pd.identificatie AND
+                                  io.versie_identificatie = io_pd.eodversie),
+    effectieve_onderzoeken AS (SELECT /*+ MATERIALIZE */
+                                      io.identificatie
+                                    , io.object_identificatie
+                                    , ao.adresvolgnummer AS object_volgnummer
+                                    , io.inonderzoek
+                                    , io.begin_onderzoek
+                                    , io.eind_onderzoek
+                               FROM   in_onderzoeken io
+                               INNER JOIN authentieke_objecten ao ON io.object_identificatie = ao.adresnummer
+                               JOIN cyclus c ON ao.adresnummer = c.object_nummer AND
+							                    ao.adresvolgnummer = c.object_volgnummer
+                               WHERE cyclus_in_onderzoek(c.begin_cyclus, c.eind_cyclus,
+                                                         io.begin_onderzoek, io.eind_onderzoek) = 1
+                               ORDER BY io.object_identificatie, ao.adresvolgnummer
+                               )
+SELECT      a.adresnummer                                                                          AS identificatie
      ,      a.adresvolgnummer                                                                      AS volgnummer
      ,      a.statuscode                                                                           AS status_code
      ,      s.omschrijving                                                                         AS status_omschrijving
@@ -91,21 +103,17 @@ SELECT a.adresnummer                                                            
      ,      to_char(a.datumopvoer, 'YYYY-MM-DD HH24:MI:SS')                                        AS begin_geldigheid
      ,      to_char(q2.datumopvoer, 'YYYY-MM-DD HH24:MI:SS')                                       AS eind_geldigheid
      , (SELECT CASE
-               WHEN listagg(inonderzoek, ';') WITHIN GROUP (ORDER BY object_identificatie) LIKE '%J%'
+               WHEN listagg(inonderzoek, ';') LIKE '%J%'
                THEN 'J'
                ELSE 'N'
                END
-        FROM  in_onderzoeken_eod io
-        WHERE io.object_identificatie = a.adresnummer
-          AND cyclus_in_onderzoek(trunc(a.datumopvoer), q2.eind_cyclus,
-                                  io.begin_onderzoek, io.eind_onderzoek) = 1
-       )                                                                                      AS aanduiding_in_onderzoek
+        FROM   effectieve_onderzoeken io
+        WHERE  io.object_identificatie = a.adresnummer AND io.object_volgnummer = a.adresvolgnummer
+       )                                                                                           AS aanduiding_in_onderzoek
      , (SELECT listagg(identificatie, ';')
-        FROM   in_onderzoeken io
-        WHERE  object_identificatie = a.adresnummer
-          AND  cyclus_in_onderzoek(trunc(a.datumopvoer), q2.eind_cyclus,
-                                   io.begin_onderzoek, io.eind_onderzoek) = 1
-       )                                                                                      AS heeft_onderzoeken
+        FROM   effectieve_onderzoeken io
+        WHERE  io.object_identificatie = a.adresnummer AND io.object_volgnummer = a.adresvolgnummer
+       )                                                                                           AS heeft_onderzoeken
      ,      a.adrestype                                                                            AS type_aot_code
      ,      t.omschrijving                                                                         AS type_aot_omschrijving
      ,      to_char(a.dd_document, 'YYYY-MM-DD')                                                   AS documentdatum

--- a/gobconfig/import_/data/sql/bag/openbareruimtes.sql
+++ b/gobconfig/import_/data/sql/bag/openbareruimtes.sql
@@ -1,9 +1,9 @@
 WITH
     -- Utility functions
     -- Use max_date if eindgeldigheid is NULL
-    FUNCTION max_date RETURN char AS
+    FUNCTION max_date RETURN DATE AS
     BEGIN
-        RETURN to_date(9999, 'yyyy');
+        RETURN to_date('9999', 'yyyy');
     END;
     -- Determine if a cycle of an objectklasse is in onderzoek
     FUNCTION cyclus_in_onderzoek(
@@ -33,29 +33,6 @@ WITH
         ELSE RETURN 0;
         END IF;
 	END;
-    -- SubQuery Factoring for onderzoeken
-    -- Alle onderzoeken voor deze objectklasse
-    in_onderzoeken AS (SELECT /*+ MATERIALIZE */
-                              identificatie
-                            , versie_identificatie
-                            , object_identificatie
-                            , inonderzoek
-                            , to_date(begin_geldigheid, 'yyyy-mm-dd')                 AS begin_onderzoek
-                            , nvl(to_date(eind_geldigheid, 'yyyy-mm-dd'), max_date()) AS eind_onderzoek
-                       FROM   lvbag.inonderzoek
-                       WHERE  objecttype = 20 ORDER BY object_identificatie),
-    -- All onderzoeken gegroepeerd per dag op maximum versie
-    -- Onderzoeken die meerdere statussen hebben per dag worden beoordeeld op de status aan het einde van de dag
-    in_onderzoeken_eod AS (SELECT /*+ MATERIALIZE */ io.*
-            	 	       FROM in_onderzoeken io
-                           INNER JOIN (SELECT   identificatie
-                                              , begin_onderzoek
-                                              , max(versie_identificatie) AS maxversie
-                                       FROM     in_onderzoeken
-                                       GROUP BY identificatie, begin_onderzoek) io_eod
-                           ON io.identificatie = io_eod.identificatie AND
-                              io.versie_identificatie = io_eod.maxversie
-                           WHERE io.inonderzoek = 'J'),
     -- SubQuery factoring for objectklasse dataset
     authentieke_objecten AS (SELECT *
                              FROM   basis.openbareruimte
@@ -64,20 +41,55 @@ WITH
     -- begindatum gebruiken als einddatum volgende cyclus
     begin_cyclus AS (SELECT openbareruimtenummer
 	                      , openbareruimtevolgnummer
+                          , datumopvoer
 	                      , 1 + dense_rank() OVER (partition BY openbareruimtenummer ORDER BY openbareruimtevolgnummer) AS rang
 	                 FROM   authentieke_objecten),
     eind_cyclus AS (SELECT openbareruimtenummer
 	                     , openbareruimtevolgnummer
 	                     , datumopvoer
-                         , nvl(trunc(datumopvoer), max_date()) as eind_cyclus
 	                     , dense_rank() OVER (partition BY openbareruimtenummer ORDER BY openbareruimtevolgnummer) AS rang
 	                FROM   authentieke_objecten),
-    -- SubQuery factoring for shared datasets
-    adressen AS (SELECT   adres_id
-                        , adresnummer
-                 FROM     basis.adres
-                 WHERE    indauthentiek = 'J'
-                 GROUP BY adres_id, adresnummer)
+ 	cyclus AS (SELECT bc.openbareruimtenummer                AS object_nummer
+	                , bc.openbareruimtevolgnummer            AS object_volgnummer
+	                , trunc(bc.datumopvoer)                  AS begin_cyclus
+	                , nvl(trunc(ec.datumopvoer), max_date()) AS eind_cyclus
+	           FROM begin_cyclus bc
+	           LEFT OUTER JOIN eind_cyclus ec ON  bc.openbareruimtenummer = ec.openbareruimtenummer AND
+							                      bc.rang = ec.rang),
+    -- SubQuery Factoring for onderzoeken
+    -- All onderzoeken gegroepeerd per onderzoek per object per dag op de toestand aan het einde van de dag
+    inonderzoeken_per_dag AS (SELECT identificatie
+                                   , object_identificatie
+                                   , begin_geldigheid
+                                   , max(versie_identificatie) AS eodversie
+                              FROM   lvbag.inonderzoek
+                              WHERE  objecttype = 20
+                              GROUP BY identificatie, object_identificatie, begin_geldigheid),
+    in_onderzoeken AS (SELECT io.identificatie
+                            , io.versie_identificatie
+                            , io.object_identificatie
+                            , io.inonderzoek
+                            , to_date(io.begin_geldigheid, 'yyyy-mm-dd')                 AS begin_onderzoek
+                            , nvl(to_date(io.eind_geldigheid, 'yyyy-mm-dd'), max_date()) AS eind_onderzoek
+                       FROM   lvbag.inonderzoek io
+                       INNER JOIN inonderzoeken_per_dag io_pd
+                               ON io.identificatie = io_pd.identificatie AND
+                                  io.versie_identificatie = io_pd.eodversie),
+    effectieve_onderzoeken AS (SELECT /*+ MATERIALIZE */
+                                      io.identificatie
+                                    , io.object_identificatie
+                                    , ao.openbareruimtevolgnummer AS object_volgnummer
+                                    , io.inonderzoek
+                                    , io.begin_onderzoek
+                                    , io.eind_onderzoek
+                               FROM   in_onderzoeken io
+                               INNER JOIN authentieke_objecten ao ON io.object_identificatie = ao.openbareruimtenummer
+                               JOIN cyclus c ON ao.openbareruimtenummer = c.object_nummer AND
+							                    ao.openbareruimtevolgnummer = c.object_volgnummer
+                               WHERE cyclus_in_onderzoek(c.begin_cyclus, c.eind_cyclus,
+                                                         io.begin_onderzoek, io.eind_onderzoek) = 1
+                               ORDER BY io.object_identificatie, ao.openbareruimtevolgnummer
+                               )
 SELECT o.openbareruimtenummer                                                                 AS identificatie
      , o.openbareruimtevolgnummer                                                             AS volgnummer
      , o.status_id                                                                            AS status_code
@@ -86,20 +98,16 @@ SELECT o.openbareruimtenummer                                                   
      , to_char(q2.datumopvoer, 'YYYY-MM-DD HH24:MI:SS')                                       AS eind_geldigheid
      , o.indgeconstateerd                                                                     AS geconstateerd
      , (SELECT CASE
-               WHEN listagg(inonderzoek, ';') WITHIN GROUP (ORDER BY object_identificatie) LIKE '%J%'
+               WHEN listagg(inonderzoek, ';') LIKE '%J%'
                THEN 'J'
                ELSE 'N'
                END
-        FROM  in_onderzoeken_eod io
-        WHERE io.object_identificatie = o.openbareruimtenummer
-          AND cyclus_in_onderzoek(trunc(o.datumopvoer), q2.eind_cyclus,
-                                  io.begin_onderzoek, io.eind_onderzoek) = 1
+        FROM   effectieve_onderzoeken io
+        WHERE  io.object_identificatie = o.openbareruimtenummer AND io.object_volgnummer = o.openbareruimtevolgnummer
        )                                                                                      AS aanduiding_in_onderzoek
      , (SELECT listagg(identificatie, ';')
-        FROM   in_onderzoeken io
-        WHERE  object_identificatie = o.openbareruimtenummer
-          AND  cyclus_in_onderzoek(trunc(o.datumopvoer), q2.eind_cyclus,
-                                   io.begin_onderzoek, io.eind_onderzoek) = 1
+        FROM   effectieve_onderzoeken io
+        WHERE  io.object_identificatie = o.openbareruimtenummer AND io.object_volgnummer = o.openbareruimtevolgnummer
        )                                                                                      AS heeft_onderzoeken
      , to_char(o.dd_document, 'YYYY-MM-DD')                                                   AS documentdatum
      , o.documentnummer                                                                       AS documentnummer

--- a/gobconfig/import_/data/sql/bag/panden.sql
+++ b/gobconfig/import_/data/sql/bag/panden.sql
@@ -1,9 +1,9 @@
 WITH
     -- Utility functions
     -- Use max_date if eindgeldigheid is NULL
-    FUNCTION max_date RETURN char AS
+    FUNCTION max_date RETURN DATE AS
     BEGIN
-        RETURN to_date(9999, 'yyyy');
+        RETURN to_date('9999', 'yyyy');
     END;
     -- Determine if a cycle of an objectklasse is in onderzoek
     FUNCTION cyclus_in_onderzoek(
@@ -33,29 +33,6 @@ WITH
         ELSE RETURN 0;
         END IF;
 	END;
-    -- SubQuery Factoring for onderzoeken
-    -- Alle onderzoeken voor deze objectklasse
-    in_onderzoeken AS (SELECT /*+ MATERIALIZE */
-                              identificatie
-                            , versie_identificatie
-                            , object_identificatie
-                            , inonderzoek
-                            , to_date(begin_geldigheid, 'yyyy-mm-dd')                 AS begin_onderzoek
-                            , nvl(to_date(eind_geldigheid, 'yyyy-mm-dd'), max_date()) AS eind_onderzoek
-                       FROM   lvbag.inonderzoek
-                       WHERE  objecttype = 101 ORDER BY object_identificatie),
-    -- All onderzoeken gegroepeerd per dag op maximum versie
-    -- Onderzoeken die meerdere statussen hebben per dag worden beoordeeld op de status aan het einde van de dag
-    in_onderzoeken_eod AS (SELECT /*+ MATERIALIZE */ io.*
-            	 	       FROM in_onderzoeken io
-                           INNER JOIN (SELECT   identificatie
-                                              , begin_onderzoek
-                                              , max(versie_identificatie) AS maxversie
-                                       FROM     in_onderzoeken
-                                       GROUP BY identificatie, begin_onderzoek) io_eod
-                           ON io.identificatie = io_eod.identificatie AND
-                              io.versie_identificatie = io_eod.maxversie
-                           WHERE io.inonderzoek = 'J'),
     -- SubQuery factoring for objectklasse dataset
     authentieke_objecten AS (SELECT *
                              FROM   basis.gebouw
@@ -64,34 +41,71 @@ WITH
     -- begindatum gebruiken als einddatum volgende cyclus
     begin_cyclus AS (SELECT gebouwnummer
 	                      , gebouwvolgnummer
+                          , datumopvoer
 	                      , 1 + dense_rank() OVER (partition BY gebouwnummer ORDER BY gebouwvolgnummer) AS rang
 	                 FROM   authentieke_objecten),
     eind_cyclus AS (SELECT gebouwnummer
 	                     , gebouwvolgnummer
 	                     , datumopvoer
-                         , nvl(trunc(datumopvoer), max_date()) as eind_cyclus
 	                     , dense_rank() OVER (partition BY gebouwnummer ORDER BY gebouwvolgnummer) AS rang
-	                FROM   authentieke_objecten)
+	                FROM   authentieke_objecten),
+ 	cyclus AS (SELECT bc.gebouwnummer                        AS object_nummer
+	                , bc.gebouwvolgnummer                    AS object_volgnummer
+	                , trunc(bc.datumopvoer)                  AS begin_cyclus
+	                , nvl(trunc(ec.datumopvoer), max_date()) AS eind_cyclus
+	           FROM begin_cyclus bc
+	           LEFT OUTER JOIN eind_cyclus ec ON  bc.gebouwnummer = ec.gebouwnummer AND
+							                      bc.rang = ec.rang),
+    -- SubQuery Factoring for onderzoeken
+    -- All onderzoeken gegroepeerd per onderzoek per object per dag op de toestand aan het einde van de dag
+    inonderzoeken_per_dag AS (SELECT identificatie
+                                   , object_identificatie
+                                   , begin_geldigheid
+                                   , max(versie_identificatie) AS eodversie
+                              FROM   lvbag.inonderzoek
+                              WHERE  objecttype = 101
+                              GROUP BY identificatie, object_identificatie, begin_geldigheid),
+    in_onderzoeken AS (SELECT io.identificatie
+                            , io.versie_identificatie
+                            , io.object_identificatie
+                            , io.inonderzoek
+                            , to_date(io.begin_geldigheid, 'yyyy-mm-dd')                 AS begin_onderzoek
+                            , nvl(to_date(io.eind_geldigheid, 'yyyy-mm-dd'), max_date()) AS eind_onderzoek
+                       FROM   lvbag.inonderzoek io
+                       INNER JOIN inonderzoeken_per_dag io_pd
+                               ON io.identificatie = io_pd.identificatie AND
+                                  io.versie_identificatie = io_pd.eodversie),
+    effectieve_onderzoeken AS (SELECT /*+ MATERIALIZE */
+                                      io.identificatie
+                                    , io.object_identificatie
+                                    , ao.gebouwvolgnummer AS object_volgnummer
+                                    , io.inonderzoek
+                                    , io.begin_onderzoek
+                                    , io.eind_onderzoek
+                               FROM   in_onderzoeken io
+                               INNER JOIN authentieke_objecten ao ON io.object_identificatie = ao.gebouwnummer
+                               JOIN cyclus c ON ao.gebouwnummer = c.object_nummer AND
+							                    ao.gebouwvolgnummer = c.object_volgnummer
+                               WHERE cyclus_in_onderzoek(c.begin_cyclus, c.eind_cyclus,
+                                                         io.begin_onderzoek, io.eind_onderzoek) = 1
+                               ORDER BY io.object_identificatie, ao.gebouwvolgnummer
+                               )
 SELECT g.gebouwnummer                                                                         AS identificatie
      , g.gebouwvolgnummer                                                                     AS volgnummer
      , g.indgeconstateerd                                                                     AS geconstateerd
      , to_char(g.datumopvoer, 'YYYY-MM-DD HH24:MI:SS')                                        AS begin_geldigheid
      , to_char(q2.datumopvoer, 'YYYY-MM-DD HH24:MI:SS')                                       AS eind_geldigheid
      , (SELECT CASE
-               WHEN listagg(inonderzoek, ';') WITHIN GROUP (ORDER BY object_identificatie) LIKE '%J%'
+               WHEN listagg(inonderzoek, ';') LIKE '%J%'
                THEN 'J'
                ELSE 'N'
                END
-        FROM  in_onderzoeken_eod io
-        WHERE io.object_identificatie = g.gebouwnummer
-          AND cyclus_in_onderzoek(trunc(g.datumopvoer), q2.eind_cyclus,
-                                  io.begin_onderzoek, io.eind_onderzoek) = 1
+        FROM   effectieve_onderzoeken io
+        WHERE  io.object_identificatie = g.gebouwnummer AND io.object_volgnummer = g.gebouwvolgnummer
        )                                                                                      AS aanduiding_in_onderzoek
      , (SELECT listagg(identificatie, ';')
-        FROM   in_onderzoeken io
-        WHERE  object_identificatie = g.gebouwnummer
-          AND  cyclus_in_onderzoek(trunc(g.datumopvoer), q2.eind_cyclus,
-                                   io.begin_onderzoek, io.eind_onderzoek) = 1
+        FROM   effectieve_onderzoeken io
+        WHERE  io.object_identificatie = g.gebouwnummer AND io.object_volgnummer = g.gebouwvolgnummer
        )                                                                                      AS heeft_onderzoeken
      , g.status_id                                                                            AS status_code
      , s.omschrijving                                                                         AS status_omschrijving

--- a/gobconfig/import_/data/sql/bag/standplaatsen.sql
+++ b/gobconfig/import_/data/sql/bag/standplaatsen.sql
@@ -1,9 +1,9 @@
 WITH
     -- Utility functions
     -- Use max_date if eindgeldigheid is NULL
-    FUNCTION max_date RETURN char AS
+    FUNCTION max_date RETURN DATE AS
     BEGIN
-        RETURN to_date(9999, 'yyyy');
+        RETURN to_date('9999', 'yyyy');
     END;
     -- Determine if a cycle of an objectklasse is in onderzoek
     FUNCTION cyclus_in_onderzoek(
@@ -33,29 +33,6 @@ WITH
         ELSE RETURN 0;
         END IF;
 	END;
-    -- SubQuery Factoring for onderzoeken
-    -- Alle onderzoeken voor deze objectklasse
-    in_onderzoeken AS (SELECT /*+ MATERIALIZE */
-                              identificatie
-                            , versie_identificatie
-                            , object_identificatie
-                            , inonderzoek
-                            , to_date(begin_geldigheid, 'yyyy-mm-dd')                 AS begin_onderzoek
-                            , nvl(to_date(eind_geldigheid, 'yyyy-mm-dd'), max_date()) AS eind_onderzoek
-                       FROM   lvbag.inonderzoek
-                       WHERE  objecttype = 112 ORDER BY object_identificatie),
-    -- All onderzoeken gegroepeerd per dag op maximum versie
-    -- Onderzoeken die meerdere statussen hebben per dag worden beoordeeld op de status aan het einde van de dag
-    in_onderzoeken_eod AS (SELECT /*+ MATERIALIZE */ io.*
-            	 	       FROM in_onderzoeken io
-                           INNER JOIN (SELECT   identificatie
-                                              , begin_onderzoek
-                                              , max(versie_identificatie) AS maxversie
-                                       FROM     in_onderzoeken
-                                       GROUP BY identificatie, begin_onderzoek) io_eod
-                           ON io.identificatie = io_eod.identificatie AND
-                              io.versie_identificatie = io_eod.maxversie
-                           WHERE io.inonderzoek = 'J'),
     -- SubQuery factoring for objectklasse dataset
     authentieke_objecten AS (SELECT *
                              FROM   basis.standplaats
@@ -64,14 +41,55 @@ WITH
     -- begindatum gebruiken als einddatum volgende cyclus
     begin_cyclus AS (SELECT standplaatsnummer
 	                      , standplaatsvolgnummer
+                          , datumopvoer
 	                      , 1 + dense_rank() OVER (partition BY standplaatsnummer ORDER BY standplaatsvolgnummer) AS rang
 	                 FROM   authentieke_objecten),
     eind_cyclus AS (SELECT standplaatsnummer
 	                     , standplaatsvolgnummer
 	                     , datumopvoer
-                         , nvl(trunc(datumopvoer), max_date()) as eind_cyclus
 	                     , dense_rank() OVER (partition BY standplaatsnummer ORDER BY standplaatsvolgnummer) AS rang
 	                FROM   authentieke_objecten),
+ 	cyclus AS (SELECT bc.standplaatsnummer                   AS object_nummer
+	                , bc.standplaatsvolgnummer               AS object_volgnummer
+	                , trunc(bc.datumopvoer)                  AS begin_cyclus
+	                , nvl(trunc(ec.datumopvoer), max_date()) AS eind_cyclus
+	           FROM begin_cyclus bc
+	           LEFT OUTER JOIN eind_cyclus ec ON  bc.standplaatsnummer = ec.standplaatsnummer AND
+							                      bc.rang = ec.rang),
+    -- SubQuery Factoring for onderzoeken
+    -- All onderzoeken gegroepeerd per onderzoek per object per dag op de toestand aan het einde van de dag
+    inonderzoeken_per_dag AS (SELECT identificatie
+                                   , object_identificatie
+                                   , begin_geldigheid
+                                   , max(versie_identificatie) AS eodversie
+                              FROM   lvbag.inonderzoek
+                              WHERE  objecttype = 112
+                              GROUP BY identificatie, object_identificatie, begin_geldigheid),
+    in_onderzoeken AS (SELECT io.identificatie
+                            , io.versie_identificatie
+                            , io.object_identificatie
+                            , io.inonderzoek
+                            , to_date(io.begin_geldigheid, 'yyyy-mm-dd')                 AS begin_onderzoek
+                            , nvl(to_date(io.eind_geldigheid, 'yyyy-mm-dd'), max_date()) AS eind_onderzoek
+                       FROM   lvbag.inonderzoek io
+                       INNER JOIN inonderzoeken_per_dag io_pd
+                               ON io.identificatie = io_pd.identificatie AND
+                                  io.versie_identificatie = io_pd.eodversie),
+    effectieve_onderzoeken AS (SELECT /*+ MATERIALIZE */
+                                      io.identificatie
+                                    , io.object_identificatie
+                                    , ao.standplaatsvolgnummer AS object_volgnummer
+                                    , io.inonderzoek
+                                    , io.begin_onderzoek
+                                    , io.eind_onderzoek
+                               FROM   in_onderzoeken io
+                               INNER JOIN authentieke_objecten ao ON io.object_identificatie = ao.standplaatsnummer
+                               JOIN cyclus c ON ao.standplaatsnummer = c.object_nummer AND
+							                    ao.standplaatsvolgnummer = c.object_volgnummer
+                               WHERE cyclus_in_onderzoek(c.begin_cyclus, c.eind_cyclus,
+                                                         io.begin_onderzoek, io.eind_onderzoek) = 1
+                               ORDER BY io.object_identificatie, ao.standplaatsvolgnummer
+                               ),
     -- SubQuery factoring for shared datasets
     adressen AS (SELECT   adres_id
                         , adresnummer
@@ -84,20 +102,16 @@ SELECT s.standplaatsnummer                                                      
      , to_char(s.datumopvoer, 'YYYY-MM-DD HH24:MI:SS')                                        AS begin_geldigheid
      , to_char(q2.datumopvoer, 'YYYY-MM-DD HH24:MI:SS')                                       AS eind_geldigheid
      , (SELECT CASE
-               WHEN listagg(inonderzoek, ';') WITHIN GROUP (ORDER BY object_identificatie) LIKE '%J%'
+               WHEN listagg(inonderzoek, ';') LIKE '%J%'
                THEN 'J'
                ELSE 'N'
                END
-        FROM  in_onderzoeken_eod io
-        WHERE io.object_identificatie = s.standplaatsnummer
-          AND cyclus_in_onderzoek(trunc(s.datumopvoer), q2.eind_cyclus,
-                                  io.begin_onderzoek, io.eind_onderzoek) = 1
+        FROM   effectieve_onderzoeken io
+        WHERE  io.object_identificatie = s.standplaatsnummer AND io.object_volgnummer = s.standplaatsvolgnummer
        )                                                                                      AS aanduiding_in_onderzoek
      , (SELECT listagg(identificatie, ';')
-        FROM   in_onderzoeken io
-        WHERE  object_identificatie = s.standplaatsnummer
-          AND  cyclus_in_onderzoek(trunc(s.datumopvoer), q2.eind_cyclus,
-                                   io.begin_onderzoek, io.eind_onderzoek) = 1
+        FROM   effectieve_onderzoeken io
+        WHERE  io.object_identificatie = s.standplaatsnummer AND io.object_volgnummer = s.standplaatsvolgnummer
        )                                                                                      AS heeft_onderzoeken
      , t.status                                                                               AS status_code
      , t.omschrijving                                                                         AS status_omschrijving

--- a/gobconfig/import_/data/sql/bag/verblijfsobjecten.sql
+++ b/gobconfig/import_/data/sql/bag/verblijfsobjecten.sql
@@ -1,9 +1,9 @@
 WITH
     -- Utility functions
     -- Use max_date if eindgeldigheid is NULL
-    FUNCTION max_date RETURN char AS
+    FUNCTION max_date RETURN DATE AS
     BEGIN
-        RETURN to_date(9999, 'yyyy');
+        RETURN to_date('9999', 'yyyy');
     END;
     -- Determine if a cycle of an objectklasse is in onderzoek
     FUNCTION cyclus_in_onderzoek(
@@ -33,29 +33,6 @@ WITH
         ELSE RETURN 0;
         END IF;
 	END;
-    -- SubQuery Factoring for onderzoeken
-    -- Alle onderzoeken voor deze objectklasse
-    in_onderzoeken AS (SELECT /*+ MATERIALIZE */
-                              identificatie
-                            , versie_identificatie
-                            , object_identificatie
-                            , inonderzoek
-                            , to_date(begin_geldigheid, 'yyyy-mm-dd')                 AS begin_onderzoek
-                            , nvl(to_date(eind_geldigheid, 'yyyy-mm-dd'), max_date()) AS eind_onderzoek
-                       FROM   lvbag.inonderzoek
-                       WHERE  objecttype = 102 ORDER BY object_identificatie),
-    -- All onderzoeken gegroepeerd per dag op maximum versie
-    -- Onderzoeken die meerdere statussen hebben per dag worden beoordeeld op de status aan het einde van de dag
-    in_onderzoeken_eod AS (SELECT /*+ MATERIALIZE */ io.*
-            	 	       FROM in_onderzoeken io
-                           INNER JOIN (SELECT   identificatie
-                                              , begin_onderzoek
-                                              , max(versie_identificatie) AS maxversie
-                                       FROM     in_onderzoeken
-                                       GROUP BY identificatie, begin_onderzoek) io_eod
-                           ON io.identificatie = io_eod.identificatie AND
-                              io.versie_identificatie = io_eod.maxversie
-                           WHERE io.inonderzoek = 'J'),
     -- SubQuery factoring for objectklasse dataset
     authentieke_objecten AS (SELECT *
                              FROM   basis.verblijfseenheid
@@ -64,14 +41,55 @@ WITH
     -- begindatum gebruiken als einddatum volgende cyclus
     begin_cyclus AS (SELECT verblijfseenheidnummer
 	                      , verblijfseenheidvolgnummer
+                          , datumopvoer
 	                      , 1 + dense_rank() OVER (partition BY verblijfseenheidnummer ORDER BY verblijfseenheidvolgnummer) AS rang
 	                 FROM   authentieke_objecten),
     eind_cyclus AS (SELECT verblijfseenheidnummer
 	                     , verblijfseenheidvolgnummer
 	                     , datumopvoer
-                         , nvl(trunc(datumopvoer), max_date()) as eind_cyclus
 	                     , dense_rank() OVER (partition BY verblijfseenheidnummer ORDER BY verblijfseenheidvolgnummer) AS rang
 	                FROM   authentieke_objecten),
+ 	cyclus AS (SELECT bc.verblijfseenheidnummer              AS object_nummer
+	                , bc.verblijfseenheidvolgnummer          AS object_volgnummer
+	                , trunc(bc.datumopvoer)                  AS begin_cyclus
+	                , nvl(trunc(ec.datumopvoer), max_date()) AS eind_cyclus
+	           FROM begin_cyclus bc
+	           LEFT OUTER JOIN eind_cyclus ec ON  bc.verblijfseenheidnummer = ec.verblijfseenheidnummer AND
+							                      bc.rang = ec.rang),
+    -- SubQuery Factoring for onderzoeken
+    -- All onderzoeken gegroepeerd per onderzoek per object per dag op de toestand aan het einde van de dag
+    inonderzoeken_per_dag AS (SELECT identificatie
+                                   , object_identificatie
+                                   , begin_geldigheid
+                                   , max(versie_identificatie) AS eodversie
+                              FROM   lvbag.inonderzoek
+                              WHERE  objecttype = 102
+                              GROUP BY identificatie, object_identificatie, begin_geldigheid),
+    in_onderzoeken AS (SELECT io.identificatie
+                            , io.versie_identificatie
+                            , io.object_identificatie
+                            , io.inonderzoek
+                            , to_date(io.begin_geldigheid, 'yyyy-mm-dd')                 AS begin_onderzoek
+                            , nvl(to_date(io.eind_geldigheid, 'yyyy-mm-dd'), max_date()) AS eind_onderzoek
+                       FROM   lvbag.inonderzoek io
+                       INNER JOIN inonderzoeken_per_dag io_pd
+                               ON io.identificatie = io_pd.identificatie AND
+                                  io.versie_identificatie = io_pd.eodversie),
+    effectieve_onderzoeken AS (SELECT /*+ MATERIALIZE */
+                                      io.identificatie
+                                    , io.object_identificatie
+                                    , ao.verblijfseenheidvolgnummer AS object_volgnummer
+                                    , io.inonderzoek
+                                    , io.begin_onderzoek
+                                    , io.eind_onderzoek
+                               FROM   in_onderzoeken io
+                               INNER JOIN authentieke_objecten ao ON io.object_identificatie = ao.verblijfseenheidnummer
+                               JOIN cyclus c ON ao.verblijfseenheidnummer = c.object_nummer AND
+							                    ao.verblijfseenheidvolgnummer = c.object_volgnummer
+                               WHERE cyclus_in_onderzoek(c.begin_cyclus, c.eind_cyclus,
+                                                         io.begin_onderzoek, io.eind_onderzoek) = 1
+                               ORDER BY io.object_identificatie, ao.verblijfseenheidvolgnummer
+                               ),
     -- SubQuery factoring for shared datasets
     adressen AS (SELECT   adres_id
                         , adresnummer
@@ -85,20 +103,16 @@ SELECT v.verblijfseenheidnummer                                                 
      , to_char(v.datumopvoer, 'YYYY-MM-DD HH24:MI:SS')                                        AS begin_geldigheid
      , to_char(q2.datumopvoer, 'YYYY-MM-DD HH24:MI:SS')                                       AS eind_geldigheid
      , (SELECT CASE
-               WHEN listagg(inonderzoek, ';') WITHIN GROUP (ORDER BY object_identificatie) LIKE '%J%'
+               WHEN listagg(inonderzoek, ';') LIKE '%J%'
                THEN 'J'
                ELSE 'N'
                END
-        FROM  in_onderzoeken_eod io
-        WHERE io.object_identificatie = v.verblijfseenheidnummer
-          AND cyclus_in_onderzoek(trunc(v.datumopvoer), q2.eind_cyclus,
-                                  io.begin_onderzoek, io.eind_onderzoek) = 1
+        FROM   effectieve_onderzoeken io
+        WHERE  io.object_identificatie = v.verblijfseenheidnummer AND io.object_volgnummer = v.verblijfseenheidvolgnummer
        )                                                                                      AS aanduiding_in_onderzoek
      , (SELECT listagg(identificatie, ';')
-        FROM   in_onderzoeken io
-        WHERE  object_identificatie = v.verblijfseenheidnummer
-          AND  cyclus_in_onderzoek(trunc(v.datumopvoer), q2.eind_cyclus,
-                                   io.begin_onderzoek, io.eind_onderzoek) = 1
+        FROM   effectieve_onderzoeken io
+        WHERE  io.object_identificatie = v.verblijfseenheidnummer AND io.object_volgnummer = v.verblijfseenheidvolgnummer
        )                                                                                      AS heeft_onderzoeken
      , v.indgeconstateerd                                                                     AS geconstateerd
      , to_char(v.dd_document, 'YYYY-MM-DD')                                                   AS documentdatum

--- a/gobconfig/import_/data/sql/bag/woonplaatsen.sql
+++ b/gobconfig/import_/data/sql/bag/woonplaatsen.sql
@@ -1,9 +1,9 @@
 WITH
     -- Utility functions
     -- Use max_date if eindgeldigheid is NULL
-    FUNCTION max_date RETURN char AS
+    FUNCTION max_date RETURN DATE AS
     BEGIN
-        RETURN to_date(9999, 'yyyy');
+        RETURN to_date('9999', 'yyyy');
     END;
     -- Determine if a cycle of an objectklasse is in onderzoek
     FUNCTION cyclus_in_onderzoek(
@@ -33,29 +33,6 @@ WITH
         ELSE RETURN 0;
         END IF;
 	END;
-    -- SubQuery Factoring for onderzoeken
-    -- Alle onderzoeken voor deze objectklasse
-    in_onderzoeken AS (SELECT /*+ MATERIALIZE */
-                              identificatie
-                            , versie_identificatie
-                            , object_identificatie
-                            , inonderzoek
-                            , to_date(begin_geldigheid, 'yyyy-mm-dd')                 AS begin_onderzoek
-                            , nvl(to_date(eind_geldigheid, 'yyyy-mm-dd'), max_date()) AS eind_onderzoek
-                       FROM   lvbag.inonderzoek
-                       WHERE  objecttype = 113 ORDER BY object_identificatie),
-    -- All onderzoeken gegroepeerd per dag op maximum versie
-    -- Onderzoeken die meerdere statussen hebben per dag worden beoordeeld op de status aan het einde van de dag
-    in_onderzoeken_eod AS (SELECT /*+ MATERIALIZE */ io.*
-            	 	       FROM in_onderzoeken io
-                           INNER JOIN (SELECT   identificatie
-                                              , begin_onderzoek
-                                              , max(versie_identificatie) AS maxversie
-                                       FROM     in_onderzoeken
-                                       GROUP BY identificatie, begin_onderzoek) io_eod
-                           ON io.identificatie = io_eod.identificatie AND
-                              io.versie_identificatie = io_eod.maxversie
-                           WHERE io.inonderzoek = 'J'),
     -- SubQuery factoring for objectklasse dataset
     authentieke_objecten AS (SELECT *
                              FROM   basis.woonplaats
@@ -64,14 +41,55 @@ WITH
     -- begindatum gebruiken als einddatum volgende cyclus
     begin_cyclus AS (SELECT woonplaatsnummer
 	                      , woonplaatsvolgnummer
+                          , datumopvoer
 	                      , 1 + dense_rank() OVER (partition BY woonplaatsnummer ORDER BY woonplaatsvolgnummer) AS rang
 	                 FROM   authentieke_objecten),
     eind_cyclus AS (SELECT woonplaatsnummer
 	                     , woonplaatsvolgnummer
 	                     , datumopvoer
-                         , nvl(trunc(datumopvoer), max_date()) as eind_cyclus
 	                     , dense_rank() OVER (partition BY woonplaatsnummer ORDER BY woonplaatsvolgnummer) AS rang
-	                FROM   authentieke_objecten)
+	                FROM   authentieke_objecten),
+ 	cyclus AS (SELECT bc.woonplaatsnummer                    AS object_nummer
+	                , bc.woonplaatsvolgnummer                AS object_volgnummer
+	                , trunc(bc.datumopvoer)                  AS begin_cyclus
+	                , nvl(trunc(ec.datumopvoer), max_date()) AS eind_cyclus
+	           FROM begin_cyclus bc
+	           LEFT OUTER JOIN eind_cyclus ec ON  bc.woonplaatsnummer = ec.woonplaatsnummer AND
+							                      bc.rang = ec.rang),
+    -- SubQuery Factoring for onderzoeken
+    -- All onderzoeken gegroepeerd per onderzoek per object per dag op de toestand aan het einde van de dag
+    inonderzoeken_per_dag AS (SELECT identificatie
+                                   , object_identificatie
+                                   , begin_geldigheid
+                                   , max(versie_identificatie) AS eodversie
+                              FROM   lvbag.inonderzoek
+                              WHERE  objecttype = 113
+                              GROUP BY identificatie, object_identificatie, begin_geldigheid),
+    in_onderzoeken AS (SELECT io.identificatie
+                            , io.versie_identificatie
+                            , io.object_identificatie
+                            , io.inonderzoek
+                            , to_date(io.begin_geldigheid, 'yyyy-mm-dd')                 AS begin_onderzoek
+                            , nvl(to_date(io.eind_geldigheid, 'yyyy-mm-dd'), max_date()) AS eind_onderzoek
+                       FROM   lvbag.inonderzoek io
+                       INNER JOIN inonderzoeken_per_dag io_pd
+                               ON io.identificatie = io_pd.identificatie AND
+                                  io.versie_identificatie = io_pd.eodversie),
+    effectieve_onderzoeken AS (SELECT /*+ MATERIALIZE */
+                                      io.identificatie
+                                    , io.object_identificatie
+                                    , ao.woonplaatsvolgnummer AS object_volgnummer
+                                    , io.inonderzoek
+                                    , io.begin_onderzoek
+                                    , io.eind_onderzoek
+                               FROM   in_onderzoeken io
+                               INNER JOIN authentieke_objecten ao ON io.object_identificatie = ao.woonplaatsnummer
+                               JOIN cyclus c ON ao.woonplaatsnummer = c.object_nummer AND
+							                    ao.woonplaatsvolgnummer = c.object_volgnummer
+                               WHERE cyclus_in_onderzoek(c.begin_cyclus, c.eind_cyclus,
+                                                         io.begin_onderzoek, io.eind_onderzoek) = 1
+                               ORDER BY io.object_identificatie, ao.woonplaatsvolgnummer
+                               )
 SELECT w.woonplaatsnummer                                                                     AS identificatie
      , w.woonplaatsvolgnummer                                                                 AS volgnummer
      , s.status                                                                               AS status_code
@@ -79,20 +97,16 @@ SELECT w.woonplaatsnummer                                                       
      , to_char(w.datumopvoer, 'YYYY-MM-DD HH24:MI:SS')                                        AS begin_geldigheid
      , to_char(q2.datumopvoer, 'YYYY-MM-DD HH24:MI:SS')                                       AS eind_geldigheid
      , (SELECT CASE
-               WHEN listagg(inonderzoek, ';') WITHIN GROUP (ORDER BY object_identificatie) LIKE '%J%'
+               WHEN listagg(inonderzoek, ';') LIKE '%J%'
                THEN 'J'
                ELSE 'N'
                END
-        FROM  in_onderzoeken_eod io
-        WHERE io.object_identificatie = w.woonplaatsnummer
-          AND cyclus_in_onderzoek(trunc(w.datumopvoer), q2.eind_cyclus,
-                                  io.begin_onderzoek, io.eind_onderzoek) = 1
+        FROM   effectieve_onderzoeken io
+        WHERE  io.object_identificatie = w.woonplaatsnummer AND io.object_volgnummer = w.woonplaatsvolgnummer
        )                                                                                      AS aanduiding_in_onderzoek
      , (SELECT listagg(identificatie, ';')
-        FROM   in_onderzoeken io
-        WHERE  object_identificatie = w.woonplaatsnummer
-          AND  cyclus_in_onderzoek(trunc(w.datumopvoer), q2.eind_cyclus,
-                                   io.begin_onderzoek, io.eind_onderzoek) = 1
+        FROM   effectieve_onderzoeken io
+        WHERE  io.object_identificatie = w.woonplaatsnummer AND io.object_volgnummer = w.woonplaatsvolgnummer
        )                                                                                      AS heeft_onderzoeken
      , w.indgeconstateerd                                                                     AS geconstateerd
      , to_char(w.dd_document, 'YYYY-MM-DD')                                                   AS documentdatum


### PR DESCRIPTION
Prepare the join between onderzoeken and object-cycli in a subquery

Unfortunatley, by fixing the bugs in the queries the processing time has been increased.

Estimated processing time to read the major BAG collections:
- panden 3,5 uur
- verblijfsobjecten 8 uur
- nummeraanduidingen 1,5 uur

Main reason for the poor performance is the absence of an index on the inonderzoeken tabel on object_identificatie.
