### PR TITLE
Changed the import query and mapping to fix data consistency test

### DIFF
--- a/gobconfig/import_/data/sql/bag/verblijfsobjecten.sql
+++ b/gobconfig/import_/data/sql/bag/verblijfsobjecten.sql
@@ -71,8 +71,10 @@ SELECT v.verblijfseenheidnummer                                                 
      , v.cbsnummer                                                                            AS cbs_nummer
      , v.woningvoorraad                                                                       AS woningvoorraad
      , q3.gebruiksdoel                                                                        AS gebruiksdoel
-     , q6.gebruiksdoel_woonfunctie                                                            AS gebruiksdoel_woonfunctie
-     , q7.gebruiksdoel_gezondheidszorg                                                        AS gebruiksdoel_gezondheidszorg
+     , q6.gebruiksdoel_woonfunctie_code                                                       AS gebruiksdoel_woonfunctie_code
+     , q6.gebruiksdoel_woonfunctie_omschrijving                                               AS gebruiksdoel_woonfunctie_omschrijving
+     , q7.gebruiksdoel_gezondheidszorg_code                                                   AS gebruiksdoel_gezondheidszorg_code
+     , q7.gebruiksdoel_gezondheidszorg_omschrijving                                           AS gebruiksdoel_gezondheidszorg_omschrijving
      , q5.toegang                                                                             AS toegang
      , q1.adresnummer                                                                         AS nummeraanduidingid_hoofd
      , q2.adresnummer                                                                         AS nummeraanduidingid_neven
@@ -160,7 +162,7 @@ FROM authentieke_objecten v
                           WHERE v.indauthentiek = 'J'
                           GROUP BY vt.id, vt.volgnummer) q5 ON v.verblijfseenheid_id = q5.verblijfsobject_id AND
                                                                v.verblijfseenheidvolgnummer = q5.verblijfsobjectvolgnummer
-    -- select gebruiksdoel_woonfunctie
+    -- select gebruiksdoel_woonfunctie_code and gebruiksdoel_woonfunctie_omschrijving 
          LEFT OUTER JOIN (SELECT vg.verblijfsobject_id
                                , vg.verblijfsobjectvolgnummer
                                , CASE g.gebruiksdoel_id
@@ -168,10 +170,18 @@ FROM authentieke_objecten v
                                  THEN CASE
                                       WHEN v.basiseenheidtype IN ('1010', '2075')
                                       THEN NULL
-                                      ELSE v.basiseenheidtype || '|' || UPPER(substr(b.omschrijving, 6, 1)) ||
+                                      ELSE v.basiseenheidtype
+                                      END
+                                 END AS gebruiksdoel_woonfunctie_code
+                               , CASE g.gebruiksdoel_id
+                                 WHEN 1
+                                 THEN CASE
+                                      WHEN v.basiseenheidtype IN ('1010', '2075')
+                                      THEN NULL
+                                      ELSE UPPER(substr(b.omschrijving, 6, 1)) ||
                                                           substr(b.omschrijving, 7, LENGTH(b.omschrijving) - 5)
                                       END
-                                 END AS gebruiksdoel_woonfunctie
+                                 END AS gebruiksdoel_woonfunctie_omschrijving
                           FROM G0363_Basis.verblijfsobject_gebruiksdoel vg
                                JOIN G0363_Basis.gebruiksdoel_vbo g ON vg.gebruiksdoel_id = g.gebruiksdoel_id
                                JOIN G0363_Basis.verblijfseenheid v ON vg.verblijfsobject_id = v.verblijfseenheid_id AND
@@ -182,8 +192,9 @@ FROM authentieke_objecten v
     -- select gebruiksdoel_gezondheidszorgfunctie
          LEFT OUTER JOIN (SELECT vg.verblijfsobject_id
                                , vg.verblijfsobjectvolgnummer
-                               , v.basiseenheidtype || '|' || UPPER(substr(b.omschrijving, 6, 1)) ||
-                                 substr(b.omschrijving, 7, LENGTH(b.omschrijving) - 5) AS gebruiksdoel_gezondheidszorg
+                               , v.basiseenheidtype AS gebruiksdoel_gezondheidszorg_code
+                               , UPPER(substr(b.omschrijving, 6, 1)) ||
+                                 substr(b.omschrijving, 7, LENGTH(b.omschrijving) - 5) AS gebruiksdoel_gezondheidszorg_omschrijving
                           FROM (SELECT x.verblijfsobject_id
                                      , x.verblijfsobjectvolgnummer
                                      , MIN(x.gebruiksdoel_id) AS min_gebruiksdoel

--- a/gobconfig/import_/data/verblijfsobjecten.json
+++ b/gobconfig/import_/data/verblijfsobjecten.json
@@ -50,7 +50,8 @@
       "source_mapping": "geometrie"
     },
     "gebruiksdoel": {
-      "source_mapping": "gebruiksdoel"
+      "source_mapping": "gebruiksdoel",
+      "enriched": true
     },
     "oppervlakte": {
       "source_mapping": "oppervlakte"
@@ -85,10 +86,16 @@
       "source_mapping": "documentnummer"
     },
     "gebruiksdoel_woonfunctie": {
-      "source_mapping": "gebruiksdoel_woonfunctie"
+      "source_mapping": {
+        "code": "gebruiksdoel_woonfunctie_code",
+        "omschrijving": "gebruiksdoel_woonfunctie_omschrijving"
+      }
     },
     "gebruiksdoel_gezondheidszorgfunctie": {
-      "source_mapping": "gebruiksdoel_gezondheidszorg"
+      "source_mapping": {
+        "code": "gebruiksdoel_gezondheidszorg_code",
+        "omschrijving": "gebruiksdoel_gezondheidszorg_omschrijving"
+      }
     },
     "aantal_eenheden_complex": {
       "source_mapping": "aantal_verhuurbare_eenheden"
@@ -133,7 +140,8 @@
       }
     },
     "toegang": {
-      "source_mapping": "toegang"
+      "source_mapping": "toegang",
+      "enriched": true
     },
     "redenopvoer": {
       "source_mapping": {


### PR DESCRIPTION
The import query and mapping were changed to fix the data consistency errors for verblijfsobjecten. An enriched flag was added to be able to skip these columns on the data consistency check