### PR TITLE
Test catalogue config corrections for data consistency test

### DIFF
--- a/gobconfig/import_/data/test_ADD.json
+++ b/gobconfig/import_/data/test_ADD.json
@@ -17,6 +17,10 @@
       "encoding": "UTF-8"
     }
   },
+  "not_provided_attributes": [
+    "_expiration_date",
+    "registratiedatum"
+  ],
   "gob_mapping": {
     "string": {
       "source_mapping": "string"
@@ -73,7 +77,9 @@
       }
     },
     "incomplete_date": {
-      "source_mapping": "incomplete_date"
+      "source_mapping": {
+        "formatted": "incomplete_date_formatted"
+      }
     }
   }
 }

--- a/gobconfig/import_/data/test_AUTOID.json
+++ b/gobconfig/import_/data/test_AUTOID.json
@@ -23,6 +23,10 @@
       }
     }
   },
+  "not_provided_attributes": [
+    "_expiration_date",
+    "registratiedatum"
+  ],
   "gob_mapping": {
     "identificatie": {
       "source_mapping": "identificatie"

--- a/gobconfig/import_/data/test_AUTOID_ADD.json
+++ b/gobconfig/import_/data/test_AUTOID_ADD.json
@@ -24,6 +24,10 @@
       }
     }
   },
+  "not_provided_attributes": [
+    "_expiration_date",
+    "registratiedatum"
+  ],
   "gob_mapping": {
     "identificatie": {
       "source_mapping": "identificatie"

--- a/gobconfig/import_/data/test_AUTOID_DELETE.json
+++ b/gobconfig/import_/data/test_AUTOID_DELETE.json
@@ -24,6 +24,10 @@
       }
     }
   },
+  "not_provided_attributes": [
+    "_expiration_date",
+    "registratiedatum"
+  ],
   "gob_mapping": {
     "identificatie": {
       "source_mapping": "identificatie"

--- a/gobconfig/import_/data/test_AUTOID_MODIFY.json
+++ b/gobconfig/import_/data/test_AUTOID_MODIFY.json
@@ -24,6 +24,10 @@
       }
     }
   },
+  "not_provided_attributes": [
+    "_expiration_date",
+    "registratiedatum"
+  ],
   "gob_mapping": {
     "identificatie": {
       "source_mapping": "identificatie"

--- a/gobconfig/import_/data/test_AUTOID_STATES.json
+++ b/gobconfig/import_/data/test_AUTOID_STATES.json
@@ -23,6 +23,10 @@
       }
     }
   },
+  "not_provided_attributes": [
+    "_expiration_date",
+    "registratiedatum"
+  ],
   "gob_mapping": {
     "identificatie": {
       "source_mapping": "identificatie"

--- a/gobconfig/import_/data/test_AUTOID_STATES_PARTIAL.json
+++ b/gobconfig/import_/data/test_AUTOID_STATES_PARTIAL.json
@@ -23,6 +23,10 @@
       }
     }
   },
+  "not_provided_attributes": [
+    "_expiration_date",
+    "registratiedatum"
+  ],
   "gob_mapping": {
     "identificatie": {
       "source_mapping": "identificatie"

--- a/gobconfig/import_/data/test_AUTOID_STATES_PARTIAL_FULL.json
+++ b/gobconfig/import_/data/test_AUTOID_STATES_PARTIAL_FULL.json
@@ -23,6 +23,10 @@
       }
     }
   },
+  "not_provided_attributes": [
+    "_expiration_date",
+    "registratiedatum"
+  ],
   "gob_mapping": {
     "identificatie": {
       "source_mapping": "identificatie"

--- a/gobconfig/import_/data/test_DELETE_ALL.json
+++ b/gobconfig/import_/data/test_DELETE_ALL.json
@@ -17,6 +17,10 @@
       "encoding": "UTF-8"
     }
   },
+  "not_provided_attributes": [
+    "_expiration_date",
+    "registratiedatum"
+  ],
   "gob_mapping": {
     "string": {
       "source_mapping": "string"
@@ -63,7 +67,9 @@
       }
     },
     "incomplete_date": {
-      "source_mapping": "incomplete_date"
+      "source_mapping": {
+        "formatted": "incomplete_date_formatted"
+      }
     }
   }
 }

--- a/gobconfig/import_/data/test_MODIFY1.json
+++ b/gobconfig/import_/data/test_MODIFY1.json
@@ -17,6 +17,10 @@
       "encoding": "UTF-8"
     }
   },
+  "not_provided_attributes": [
+    "_expiration_date",
+    "registratiedatum"
+  ],
   "gob_mapping": {
     "string": {
       "source_mapping": "string"
@@ -73,7 +77,9 @@
       }
     },
     "incomplete_date": {
-      "source_mapping": "incomplete_date"
+      "source_mapping": {
+        "formatted": "incomplete_date_formatted"
+      }
     }
   }
 }

--- a/gobconfig/import_/data/test_REFS.json
+++ b/gobconfig/import_/data/test_REFS.json
@@ -17,6 +17,10 @@
       "encoding": "UTF-8"
     }
   },
+  "not_provided_attributes": [
+    "_expiration_date",
+    "registratiedatum"
+  ],
   "gob_mapping": {
     "string": {
       "source_mapping": "string"

--- a/gobconfig/import_/data/test_REFS_MODIFY1.json
+++ b/gobconfig/import_/data/test_REFS_MODIFY1.json
@@ -17,6 +17,10 @@
       "encoding": "UTF-8"
     }
   },
+  "not_provided_attributes": [
+    "_expiration_date",
+    "registratiedatum"
+  ],
   "gob_mapping": {
     "string": {
       "source_mapping": "string"

--- a/gobconfig/import_/data/test_rel_collapsed_a.json
+++ b/gobconfig/import_/data/test_rel_collapsed_a.json
@@ -16,6 +16,10 @@
       "encoding": "UTF-8"
     }
   },
+  "not_provided_attributes": [
+    "_expiration_date",
+    "registratiedatum"
+  ],
   "gob_mapping": {
     "id": {
       "source_mapping": "id"

--- a/gobconfig/import_/data/test_rel_collapsed_b.json
+++ b/gobconfig/import_/data/test_rel_collapsed_b.json
@@ -16,6 +16,10 @@
       "encoding": "UTF-8"
     }
   },
+  "not_provided_attributes": [
+    "_expiration_date",
+    "registratiedatum"
+  ],
   "gob_mapping": {
     "id": {
       "source_mapping": "id"

--- a/gobconfig/import_/data/test_rel_entity_a.json
+++ b/gobconfig/import_/data/test_rel_entity_a.json
@@ -16,6 +16,10 @@
       "encoding": "UTF-8"
     }
   },
+  "not_provided_attributes": [
+    "_expiration_date",
+    "registratiedatum"
+  ],
   "gob_mapping": {
     "id": {
       "source_mapping": "id"

--- a/gobconfig/import_/data/test_rel_entity_b.json
+++ b/gobconfig/import_/data/test_rel_entity_b.json
@@ -16,6 +16,10 @@
       "encoding": "UTF-8"
     }
   },
+  "not_provided_attributes": [
+    "_expiration_date",
+    "registratiedatum"
+  ],
   "gob_mapping": {
     "id": {
       "source_mapping": "id"

--- a/gobconfig/import_/data/test_rel_entity_c.json
+++ b/gobconfig/import_/data/test_rel_entity_c.json
@@ -16,6 +16,10 @@
       "encoding": "UTF-8"
     }
   },
+  "not_provided_attributes": [
+    "_expiration_date",
+    "registratiedatum"
+  ],
   "gob_mapping": {
     "id": {
       "source_mapping": "id"

--- a/gobconfig/import_/data/test_rel_entity_d.json
+++ b/gobconfig/import_/data/test_rel_entity_d.json
@@ -16,6 +16,10 @@
       "encoding": "UTF-8"
     }
   },
+  "not_provided_attributes": [
+    "_expiration_date",
+    "registratiedatum"
+  ],
   "gob_mapping": {
     "id": {
       "source_mapping": "id"

--- a/gobconfig/import_/data/test_rel_multiple_allowed_dst_1.json
+++ b/gobconfig/import_/data/test_rel_multiple_allowed_dst_1.json
@@ -16,6 +16,10 @@
       "encoding": "UTF-8"
     }
   },
+  "not_provided_attributes": [
+    "_expiration_date",
+    "registratiedatum"
+  ],
   "gob_mapping": {
     "id": {
       "source_mapping": "id"

--- a/gobconfig/import_/data/test_rel_multiple_allowed_dst_5.json
+++ b/gobconfig/import_/data/test_rel_multiple_allowed_dst_5.json
@@ -16,6 +16,10 @@
       "encoding": "UTF-8"
     }
   },
+  "not_provided_attributes": [
+    "_expiration_date",
+    "registratiedatum"
+  ],
   "gob_mapping": {
     "id": {
       "source_mapping": "id"

--- a/gobconfig/import_/data/test_rel_multiple_allowed_dst_6.json
+++ b/gobconfig/import_/data/test_rel_multiple_allowed_dst_6.json
@@ -16,6 +16,10 @@
       "encoding": "UTF-8"
     }
   },
+  "not_provided_attributes": [
+    "_expiration_date",
+    "registratiedatum"
+  ],
   "gob_mapping": {
     "id": {
       "source_mapping": "id"

--- a/gobconfig/import_/data/test_rel_multiple_allowed_multisource_src_A1.json
+++ b/gobconfig/import_/data/test_rel_multiple_allowed_multisource_src_A1.json
@@ -16,6 +16,10 @@
       "encoding": "UTF-8"
     }
   },
+  "not_provided_attributes": [
+    "_expiration_date",
+    "registratiedatum"
+  ],
   "gob_mapping": {
     "id": {
       "source_mapping": "id"

--- a/gobconfig/import_/data/test_rel_multiple_allowed_multisource_src_A2.json
+++ b/gobconfig/import_/data/test_rel_multiple_allowed_multisource_src_A2.json
@@ -16,6 +16,10 @@
       "encoding": "UTF-8"
     }
   },
+  "not_provided_attributes": [
+    "_expiration_date",
+    "registratiedatum"
+  ],
   "gob_mapping": {
     "id": {
       "source_mapping": "id"

--- a/gobconfig/import_/data/test_rel_multiple_allowed_multisource_src_A3.json
+++ b/gobconfig/import_/data/test_rel_multiple_allowed_multisource_src_A3.json
@@ -16,6 +16,10 @@
       "encoding": "UTF-8"
     }
   },
+  "not_provided_attributes": [
+    "_expiration_date",
+    "registratiedatum"
+  ],
   "gob_mapping": {
     "id": {
       "source_mapping": "id"

--- a/gobconfig/import_/data/test_rel_multiple_allowed_multisource_src_A4.json
+++ b/gobconfig/import_/data/test_rel_multiple_allowed_multisource_src_A4.json
@@ -16,6 +16,10 @@
       "encoding": "UTF-8"
     }
   },
+  "not_provided_attributes": [
+    "_expiration_date",
+    "registratiedatum"
+  ],
   "gob_mapping": {
     "id": {
       "source_mapping": "id"

--- a/gobconfig/import_/data/test_rel_multiple_allowed_multisource_src_B1.json
+++ b/gobconfig/import_/data/test_rel_multiple_allowed_multisource_src_B1.json
@@ -16,6 +16,10 @@
       "encoding": "UTF-8"
     }
   },
+  "not_provided_attributes": [
+    "_expiration_date",
+    "registratiedatum"
+  ],
   "gob_mapping": {
     "id": {
       "source_mapping": "id"

--- a/gobconfig/import_/data/test_rel_multiple_allowed_multisource_src_B2.json
+++ b/gobconfig/import_/data/test_rel_multiple_allowed_multisource_src_B2.json
@@ -16,6 +16,10 @@
       "encoding": "UTF-8"
     }
   },
+  "not_provided_attributes": [
+    "_expiration_date",
+    "registratiedatum"
+  ],
   "gob_mapping": {
     "id": {
       "source_mapping": "id"

--- a/gobconfig/import_/data/test_rel_multiple_allowed_multisource_src_B3.json
+++ b/gobconfig/import_/data/test_rel_multiple_allowed_multisource_src_B3.json
@@ -16,6 +16,10 @@
       "encoding": "UTF-8"
     }
   },
+  "not_provided_attributes": [
+    "_expiration_date",
+    "registratiedatum"
+  ],
   "gob_mapping": {
     "id": {
       "source_mapping": "id"

--- a/gobconfig/import_/data/test_rel_multiple_allowed_multisource_src_B4.json
+++ b/gobconfig/import_/data/test_rel_multiple_allowed_multisource_src_B4.json
@@ -16,6 +16,10 @@
       "encoding": "UTF-8"
     }
   },
+  "not_provided_attributes": [
+    "_expiration_date",
+    "registratiedatum"
+  ],
   "gob_mapping": {
     "id": {
       "source_mapping": "id"

--- a/gobconfig/import_/data/test_rel_multiple_allowed_src_1.json
+++ b/gobconfig/import_/data/test_rel_multiple_allowed_src_1.json
@@ -16,6 +16,10 @@
       "encoding": "UTF-8"
     }
   },
+  "not_provided_attributes": [
+    "_expiration_date",
+    "registratiedatum"
+  ],
   "gob_mapping": {
     "id": {
       "source_mapping": "id"

--- a/gobconfig/import_/data/test_rel_multiple_allowed_src_2.json
+++ b/gobconfig/import_/data/test_rel_multiple_allowed_src_2.json
@@ -16,6 +16,10 @@
       "encoding": "UTF-8"
     }
   },
+  "not_provided_attributes": [
+    "_expiration_date",
+    "registratiedatum"
+  ],
   "gob_mapping": {
     "id": {
       "source_mapping": "id"

--- a/gobconfig/import_/data/test_rel_multiple_allowed_src_3.json
+++ b/gobconfig/import_/data/test_rel_multiple_allowed_src_3.json
@@ -16,6 +16,10 @@
       "encoding": "UTF-8"
     }
   },
+  "not_provided_attributes": [
+    "_expiration_date",
+    "registratiedatum"
+  ],
   "gob_mapping": {
     "id": {
       "source_mapping": "id"

--- a/gobconfig/import_/data/test_rel_multiple_allowed_src_4.json
+++ b/gobconfig/import_/data/test_rel_multiple_allowed_src_4.json
@@ -16,6 +16,10 @@
       "encoding": "UTF-8"
     }
   },
+  "not_provided_attributes": [
+    "_expiration_date",
+    "registratiedatum"
+  ],
   "gob_mapping": {
     "id": {
       "source_mapping": "id"


### PR DESCRIPTION
Add attributes that are not provided within the test catalogue as `not_provided_attributes` and fix the mapping for `incomplete_date` in order to get rid of test catalogue errors and warnings in data consistency test execution.