### PR TITLE
Revert config update for incomplete date

### DIFF
--- a/gobconfig/import_/data/test_ADD.json
+++ b/gobconfig/import_/data/test_ADD.json
@@ -77,9 +77,7 @@
       }
     },
     "incomplete_date": {
-      "source_mapping": {
-        "formatted": "incomplete_date_formatted"
-      }
+      "source_mapping": "incomplete_date"
     }
   }
 }

--- a/gobconfig/import_/data/test_DELETE_ALL.json
+++ b/gobconfig/import_/data/test_DELETE_ALL.json
@@ -67,9 +67,7 @@
       }
     },
     "incomplete_date": {
-      "source_mapping": {
-        "formatted": "incomplete_date_formatted"
-      }
+      "source_mapping": "incomplete_date"
     }
   }
 }

--- a/gobconfig/import_/data/test_MODIFY1.json
+++ b/gobconfig/import_/data/test_MODIFY1.json
@@ -76,10 +76,8 @@
         "bronwaarde": "manyreference"
       }
     },
-    "incomplete_date": {
-      "source_mapping": {
-        "formatted": "incomplete_date_formatted"
-      }
+   "incomplete_date": {
+      "source_mapping": "incomplete_date"
     }
   }
 }


### PR DESCRIPTION
Configuration update was not in line with data type `GOB.IncompleteDate` and caused errors in the Import module.
Therefore reverting those specific mapping changes. This will (re)introduce the error `Have unexpected key left in GOB` in the data consistency test, so this still has to be solved later on, depending on the prioritization of this issue.