### PR TITLE
BRK2 ART betrokken_brk_tenaamstelling: use tng_identificatie.

### DIFF
--- a/gobconfig/import_/data/brk2.aantekeningenrechten.json
+++ b/gobconfig/import_/data/brk2.aantekeningenrechten.json
@@ -38,7 +38,7 @@
     },
     "betrokken_brk_tenaamstelling": {
       "source_mapping": {
-        "bronwaarde": "betrokken_brk_tenaamstelling.tng_id"
+        "bronwaarde": "betrokken_brk_tenaamstelling.tng_identificatie"
       }
     },
     "heeft_brk_betrokken_persoon": {


### PR DESCRIPTION
Wacht op https://github.com/Amsterdam/GOB-Config/pull/154