### PR TITLE
Update expiration date logic in verblijfsobjecten.sql

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -25,11 +25,11 @@ node('GOBBUILD') {
     stage('Test') {
         lock("gob-config-test") {
             tryStep "test", {
-                sh "docker-compose -p gobconfig build && " +
-                   "docker-compose -p gobconfig run --rm test"
+                sh "docker compose -p gobconfig build && " +
+                   "docker compose -p gobconfig run --rm test"
 
             }, {
-                sh "docker-compose -p gobconfig down"
+                sh "docker compose -p gobconfig down"
             }
         }
     }

--- a/gobconfig/import_/data/sql/bag/ligplaatsen.sql
+++ b/gobconfig/import_/data/sql/bag/ligplaatsen.sql
@@ -61,19 +61,16 @@ SELECT l.ligplaatsnummer                                                        
      , l.ligplaats_id                                                                         AS source_id
      , l.vrijetekst2                                                                          AS gebruiksdoel
      , CASE
-         -- no endvalidity, use beginvalidity for certain status
          WHEN q2.datumopvoer IS NULL
          THEN
              CASE
-                 -- the verblijfsobject is expired at begin_geldigheid
-                 WHEN s.status = 2
-                 THEN to_char(l.datumopvoer, 'YYYY-MM-DD HH24:MI:SS')
+                 WHEN s.status = 2  -- Plaats ingetrokken
+                 THEN to_char(l.datumopvoer, 'YYYY-MM-DD HH24:MI:SS')  -- begin_geldigheid
              END
-          -- endvalidity exists
          ELSE
              CASE
                  WHEN q2.datumopvoer < sysdate
-                 THEN to_char(q2.datumopvoer, 'YYYY-MM-DD HH24:MI:SS')
+                 THEN to_char(q2.datumopvoer, 'YYYY-MM-DD HH24:MI:SS')  -- eind_geldigheid
                  ELSE to_char(l.modification, 'YYYY-MM-DD HH24:MI:SS')
              END
        END                                                                                    AS expirationdate

--- a/gobconfig/import_/data/sql/bag/nummeraanduidingen.sql
+++ b/gobconfig/import_/data/sql/bag/nummeraanduidingen.sql
@@ -45,19 +45,16 @@ SELECT      a.adresnummer                                                       
      ,      to_char(a.creation, 'YYYY-MM-DD HH24:MI:SS')                                           AS registratiedatum
      ,      a.adres_id                                                                             AS source_id
      , CASE
-         -- no endvalidity, use beginvalidity for certain status
          WHEN q2.datumopvoer IS NULL
          THEN
              CASE
-                 -- when status = 2, the verblijfsobject is expired at begin_geldigheid
-                 WHEN s.status = 2
-                 THEN to_char(a.datumopvoer, 'YYYY-MM-DD HH24:MI:SS')
+                 WHEN s.status = 2  -- Naamgeving ingetrokken
+                 THEN to_char(a.datumopvoer, 'YYYY-MM-DD HH24:MI:SS')  -- begin_geldigheid
              END
-          -- endvalidity exists
          ELSE
              CASE
                  WHEN q2.datumopvoer < sysdate
-                 THEN to_char(q2.datumopvoer, 'YYYY-MM-DD HH24:MI:SS')
+                 THEN to_char(q2.datumopvoer, 'YYYY-MM-DD HH24:MI:SS')  -- eind_geldigheid
                  ELSE to_char(a.modification, 'YYYY-MM-DD HH24:MI:SS')
              END
        END                                                                                         AS expirationdate

--- a/gobconfig/import_/data/sql/bag/nummeraanduidingen.sql
+++ b/gobconfig/import_/data/sql/bag/nummeraanduidingen.sql
@@ -44,21 +44,23 @@ SELECT      a.adresnummer                                                       
      ,      q5.standplaatsnummer                                                                   AS adresseert_bag_standplaats
      ,      to_char(a.creation, 'YYYY-MM-DD HH24:MI:SS')                                           AS registratiedatum
      ,      a.adres_id                                                                             AS source_id
-     ,      NVL2(q2.datumopvoer,
-                 CASE
+     , CASE
+         -- no endvalidity, use beginvalidity for certain status
+         WHEN q2.datumopvoer IS NULL
+         THEN
+             CASE
+                 -- when status = 2, the verblijfsobject is expired at begin_geldigheid
+                 WHEN s.status = 2
+                 THEN to_char(a.datumopvoer, 'YYYY-MM-DD HH24:MI:SS')
+             END
+          -- endvalidity exists
+         ELSE
+             CASE
                  WHEN q2.datumopvoer < sysdate
                  THEN to_char(q2.datumopvoer, 'YYYY-MM-DD HH24:MI:SS')
                  ELSE to_char(a.modification, 'YYYY-MM-DD HH24:MI:SS')
-                 END
-    , CASE WHEN s.status = 2
-           THEN
-               CASE
-               WHEN q2.datumopvoer < sysdate
-               THEN to_char(a.datumopvoer, 'YYYY-MM-DD HH24:MI:SS')
-               ELSE to_char(a.creation, 'YYYY-MM-DD HH24:MI:SS')
-               END
-      ELSE NULL
-      END)                                                                                   AS expirationdate
+             END
+       END                                                                                         AS expirationdate
      , CASE
          -- Amsterdam
          -- Woonplaatsnummer: Before 2014-01-10: 1025, after 3594 (merge with Zuidoost)

--- a/gobconfig/import_/data/sql/bag/openbareruimtes.sql
+++ b/gobconfig/import_/data/sql/bag/openbareruimtes.sql
@@ -43,19 +43,16 @@ SELECT o.openbareruimtenummer                                                   
      , to_char(o.creation, 'YYYY-MM-DD HH24:MI:SS')                                           AS registratiedatum
      , o.openbareruimte_id                                                                    AS source_id
      , CASE
-         -- no endvalidity, use beginvalidity for certain status
          WHEN q2.datumopvoer IS NULL
          THEN
              CASE
-                 -- for every status = 2 the verblijfsobject is expired at begin_geldigheid
-                 WHEN s.status = 2
-                 THEN to_char(o.datumopvoer, 'YYYY-MM-DD HH24:MI:SS')
+                 WHEN s.status = 2  -- Naamgeving ingetrokken
+                 THEN to_char(o.datumopvoer, 'YYYY-MM-DD HH24:MI:SS')  -- begin_geldigheid
              END
-          -- endvalidity exists
          ELSE
              CASE
                  WHEN q2.datumopvoer < sysdate
-                 THEN to_char(q2.datumopvoer, 'YYYY-MM-DD HH24:MI:SS')
+                 THEN to_char(q2.datumopvoer, 'YYYY-MM-DD HH24:MI:SS')  -- eind_geldigheid
                  ELSE to_char(o.modification, 'YYYY-MM-DD HH24:MI:SS')
              END
        END                                                                                    AS expirationdate

--- a/gobconfig/import_/data/sql/bag/openbareruimtes.sql
+++ b/gobconfig/import_/data/sql/bag/openbareruimtes.sql
@@ -42,21 +42,23 @@ SELECT o.openbareruimtenummer                                                   
      , m.omschrijving                                                                         AS bagproces_omschrijving
      , to_char(o.creation, 'YYYY-MM-DD HH24:MI:SS')                                           AS registratiedatum
      , o.openbareruimte_id                                                                    AS source_id
-     , NVL2(q2.datumopvoer,
-            CASE
-            WHEN q2.datumopvoer < sysdate
-            THEN to_char(q2.datumopvoer, 'YYYY-MM-DD HH24:MI:SS')
-            ELSE to_char(o.modification, 'YYYY-MM-DD HH24:MI:SS')
-            END
-    , CASE
-      WHEN s.status = 2
-      THEN CASE
-           WHEN q2.datumopvoer < sysdate
-           THEN to_char(o.datumopvoer, 'YYYY-MM-DD HH24:MI:SS')
-           ELSE to_char(o.creation, 'YYYY-MM-DD HH24:MI:SS')
-           END
-      ELSE NULL
-      END)                                                                                    AS expirationdate
+     , CASE
+         -- no endvalidity, use beginvalidity for certain status
+         WHEN q2.datumopvoer IS NULL
+         THEN
+             CASE
+                 -- for every status = 2 the verblijfsobject is expired at begin_geldigheid
+                 WHEN s.status = 2
+                 THEN to_char(o.datumopvoer, 'YYYY-MM-DD HH24:MI:SS')
+             END
+          -- endvalidity exists
+         ELSE
+             CASE
+                 WHEN q2.datumopvoer < sysdate
+                 THEN to_char(q2.datumopvoer, 'YYYY-MM-DD HH24:MI:SS')
+                 ELSE to_char(o.modification, 'YYYY-MM-DD HH24:MI:SS')
+             END
+       END                                                                                    AS expirationdate
      , sdo_util.to_wktgeometry(o.geometrie)                                                   AS geometrie
 FROM authentieke_objecten o
     -- begindatum gebruiken als einddatum volgende cyclus

--- a/gobconfig/import_/data/sql/bag/panden.sql
+++ b/gobconfig/import_/data/sql/bag/panden.sql
@@ -45,21 +45,23 @@ SELECT g.gebouwnummer                                                           
      , m.omschrijving                                                                         AS bagproces_omschrijving
      , to_char(g.creation, 'YYYY-MM-DD HH24:MI:SS')                                           AS registratiedatum
      , g.gebouw_id                                                                            AS source_id
-     , NVL2(q2.datumopvoer,
-            CASE
-            WHEN q2.datumopvoer < sysdate
-            THEN to_char(q2.datumopvoer, 'YYYY-MM-DD HH24:MI:SS')
-            ELSE to_char(g.modification, 'YYYY-MM-DD HH24:MI:SS')
-            END
-    , CASE
-      WHEN s.status NOT IN (1, 2, 3, 7, 10, 11, 12, 13)
-      THEN CASE
-           WHEN q2.datumopvoer < sysdate
-           THEN to_char(g.datumopvoer, 'YYYY-MM-DD HH24:MI:SS')
-           ELSE to_char(g.creation, 'YYYY-MM-DD HH24:MI:SS')
-           END
-      ELSE NULL
-      END)                                                                                    AS expirationdate
+     , CASE
+         -- no endvalidity, use beginvalidity for certain status
+         WHEN q2.datumopvoer IS NULL
+         THEN
+             CASE
+                 -- for every status OTHER than 1, 2, 3, 7, 10, 11, 12, 13, the verblijfsobject is expired at begin_geldigheid
+                 WHEN s.status NOT IN (1, 2, 3, 7, 10, 11, 12, 13)
+                 THEN to_char(g.datumopvoer, 'YYYY-MM-DD HH24:MI:SS')
+             END
+          -- endvalidity exists
+         ELSE
+             CASE
+                 WHEN q2.datumopvoer < sysdate
+                 THEN to_char(q2.datumopvoer, 'YYYY-MM-DD HH24:MI:SS')
+                 ELSE to_char(g.modification, 'YYYY-MM-DD HH24:MI:SS')
+             END
+       END                                                                                    AS expirationdate
       , g.modification
       , g.creation
 FROM authentieke_objecten g

--- a/gobconfig/import_/data/sql/bag/panden.sql
+++ b/gobconfig/import_/data/sql/bag/panden.sql
@@ -46,19 +46,20 @@ SELECT g.gebouwnummer                                                           
      , to_char(g.creation, 'YYYY-MM-DD HH24:MI:SS')                                           AS registratiedatum
      , g.gebouw_id                                                                            AS source_id
      , CASE
-         -- no endvalidity, use beginvalidity for certain status
          WHEN q2.datumopvoer IS NULL
          THEN
              CASE
-                 -- for every status OTHER than 1, 2, 3, 7, 10, 11, 12, 13, the verblijfsobject is expired at begin_geldigheid
-                 WHEN s.status NOT IN (1, 2, 3, 7, 10, 11, 12, 13)
-                 THEN to_char(g.datumopvoer, 'YYYY-MM-DD HH24:MI:SS')
+                 WHEN s.status IN (
+                    8,  -- Pand gesloopt
+                    9,  -- Niet gerealiseerd pand
+                    14  -- pand ten onrechte opgevoerd
+                 )
+                 THEN to_char(g.datumopvoer, 'YYYY-MM-DD HH24:MI:SS')  -- begin_geldigheid
              END
-          -- endvalidity exists
          ELSE
              CASE
                  WHEN q2.datumopvoer < sysdate
-                 THEN to_char(q2.datumopvoer, 'YYYY-MM-DD HH24:MI:SS')
+                 THEN to_char(q2.datumopvoer, 'YYYY-MM-DD HH24:MI:SS')  -- eind_geldigheid
                  ELSE to_char(g.modification, 'YYYY-MM-DD HH24:MI:SS')
              END
        END                                                                                    AS expirationdate

--- a/gobconfig/import_/data/sql/bag/standplaatsen.sql
+++ b/gobconfig/import_/data/sql/bag/standplaatsen.sql
@@ -61,19 +61,16 @@ SELECT s.standplaatsnummer                                                      
      , s.standplaats_id                                                                       AS source_id
      , s.vrijetekst2                                                                          AS gebruiksdoel
      , CASE
-         -- no endvalidity, use beginvalidity for certain status
          WHEN q2.datumopvoer IS NULL
          THEN
              CASE
-                 -- when status = 2, the verblijfsobject is expired at begin_geldigheid
-                 WHEN s.status = 2
-                 THEN to_char(s.datumopvoer, 'YYYY-MM-DD HH24:MI:SS')
+                 WHEN s.status = 2  -- Plaats ingetrokken
+                 THEN to_char(s.datumopvoer, 'YYYY-MM-DD HH24:MI:SS')  -- begin_geldigheid
              END
-          -- endvalidity exists
          ELSE
              CASE
                  WHEN q2.datumopvoer < sysdate
-                 THEN to_char(q2.datumopvoer, 'YYYY-MM-DD HH24:MI:SS')
+                 THEN to_char(q2.datumopvoer, 'YYYY-MM-DD HH24:MI:SS')  -- eind_geldigheid
                  ELSE to_char(s.modification, 'YYYY-MM-DD HH24:MI:SS')
              END
        END                                                                                    AS expirationdate

--- a/gobconfig/import_/data/sql/bag/verblijfsobjecten.sql
+++ b/gobconfig/import_/data/sql/bag/verblijfsobjecten.sql
@@ -56,22 +56,23 @@ SELECT v.verblijfseenheidnummer                                                 
      , to_char(v.creation, 'YYYY-MM-DD HH24:MI:SS')                                           AS registratiedatum
      , v.verblijfseenheid_id                                                                  AS source_id
      , CASE
-         -- no endvalidity, use beginvalidity for certain status
          WHEN q2.datumopvoer IS NULL
          THEN
              CASE
-                 -- for every status OTHER than 1, 3, 4, 6, 7, the verblijfsobject is expired at begin_geldigheid
-                 WHEN s.status NOT IN (1, 3, 4, 6, 7)
-                 THEN to_char(v.datumopvoer, 'YYYY-MM-DD HH24:MI:SS')
+                 WHEN s.status IN (
+                     2,  -- Niet gerealiseerd verblijfsobject
+                     5,  -- Verblijfsobject ingetrokken
+                     8   -- Verblijfsobject ten onrechte opgevoerd
+                 )
+                 THEN to_char(v.datumopvoer, 'YYYY-MM-DD HH24:MI:SS')  -- begin_geldigheid
              END
-          -- endvalidity exists
          ELSE
              CASE
                  WHEN q2.datumopvoer < sysdate
-                 THEN to_char(q2.datumopvoer, 'YYYY-MM-DD HH24:MI:SS')
+                 THEN to_char(q2.datumopvoer, 'YYYY-MM-DD HH24:MI:SS')  -- eind_geldigheid
                  ELSE to_char(v.modification, 'YYYY-MM-DD HH24:MI:SS')
              END
-        END                                                                                   AS expirationdate
+       END                                                                                    AS expirationdate
      , v.bagproces                                                                            AS bagproces_code
      , m.omschrijving                                                                         AS bagproces_omschrijving
      , v.vloeroppervlakte                                                                     AS oppervlakte

--- a/gobconfig/import_/data/sql/bag/verblijfsobjecten.sql
+++ b/gobconfig/import_/data/sql/bag/verblijfsobjecten.sql
@@ -55,21 +55,23 @@ SELECT v.verblijfseenheidnummer                                                 
      , TRIM(nvl(regexp_substr(v.documentnummer, '^(.*?)_', 1, 1, NULL, 1), v.documentnummer)) AS dossier
      , to_char(v.creation, 'YYYY-MM-DD HH24:MI:SS')                                           AS registratiedatum
      , v.verblijfseenheid_id                                                                  AS source_id
-     , NVL2(q2.datumopvoer,
-            CASE
-            WHEN q2.datumopvoer < sysdate
-            THEN to_char(q2.datumopvoer, 'YYYY-MM-DD HH24:MI:SS')
-            ELSE to_char(v.modification, 'YYYY-MM-DD HH24:MI:SS')
-            END
-    , CASE
-      WHEN s.status NOT IN (1, 3, 4, 6, 7)
-      THEN CASE
-           WHEN q2.datumopvoer < sysdate
-           THEN to_char(v.datumopvoer, 'YYYY-MM-DD HH24:MI:SS')
-           ELSE to_char(v.creation, 'YYYY-MM-DD HH24:MI:SS')
-           END
-      ELSE NULL
-      END)                                                                                    AS expirationdate
+     , CASE
+         -- no endvalidity, use beginvalidity for certain status
+         WHEN q2.datumopvoer IS NULL
+         THEN
+             CASE
+                 -- for every status OTHER than 1, 3, 4, 6, 7, the verblijfsobject is expired at begin_geldigheid
+                 WHEN s.status NOT IN (1, 3, 4, 6, 7)
+                 THEN to_char(v.datumopvoer, 'YYYY-MM-DD HH24:MI:SS')
+             END
+          -- endvalidity exists
+         ELSE
+             CASE
+                 WHEN q2.datumopvoer < sysdate
+                 THEN to_char(q2.datumopvoer, 'YYYY-MM-DD HH24:MI:SS')
+                 ELSE to_char(v.modification, 'YYYY-MM-DD HH24:MI:SS')
+             END
+        END                                                                                   AS expirationdate
      , v.bagproces                                                                            AS bagproces_code
      , m.omschrijving                                                                         AS bagproces_omschrijving
      , v.vloeroppervlakte                                                                     AS oppervlakte

--- a/gobconfig/import_/data/sql/bag/woonplaatsen.sql
+++ b/gobconfig/import_/data/sql/bag/woonplaatsen.sql
@@ -44,21 +44,17 @@ WITH
       END                                                                                      AS ligt_in_gemeente
       , to_char(w.creation, 'YYYY-MM-DD HH24:MI:SS')                                           AS registratiedatum
       , w.woonplaats_id                                                                        AS source_id
-
      , CASE
-         -- no endvalidity, use beginvalidity for certain status
          WHEN q2.datumopvoer IS NULL
          THEN
              CASE
-                 -- when status = 2,, the verblijfsobject is expired at begin_geldigheid
-                 WHEN s.status = 2
-                 THEN to_char(w.datumopvoer, 'YYYY-MM-DD HH24:MI:SS')
+                 WHEN s.status = 2 -- Woonplaats ingetrokken
+                 THEN to_char(w.datumopvoer, 'YYYY-MM-DD HH24:MI:SS')  -- begin_geldigheid
              END
-          -- endvalidity exists
          ELSE
              CASE
                  WHEN q2.datumopvoer < sysdate
-                 THEN to_char(q2.datumopvoer, 'YYYY-MM-DD HH24:MI:SS')
+                 THEN to_char(q2.datumopvoer, 'YYYY-MM-DD HH24:MI:SS')  -- eind_geldigheid
                  ELSE to_char(w.modification, 'YYYY-MM-DD HH24:MI:SS')
              END
        END                                                                                     AS expirationdate


### PR DESCRIPTION
 - `WHEN q2.datumopvoer < sysdate` on line 67 never evaluates to True, because q2.datumopvoer (eindgeldigheid) is always NULL at that branch.
 - Also the registration_datum  (v.creation) should not be used to determine the expiration date
 - Replace NVL2 with CASE